### PR TITLE
Add lichess explorer options

### DIFF
--- a/src/atoms/atoms.ts
+++ b/src/atoms/atoms.ts
@@ -12,6 +12,7 @@ import EngineSettings from "@/components/panels/analysis/EngineSettings";
 import { AsyncStringStorage } from "jotai/vanilla/utils/atomWithStorage";
 import { BaseDirectory, readTextFile, removeFile, writeTextFile } from "@tauri-apps/api/fs";
 import { Engine } from "@/utils/engines";
+import { LichessGamesOptions } from "@/utils/lichess/lichessexplorer";
 
 
 const options = { dir: BaseDirectory.AppData };
@@ -158,13 +159,19 @@ function tabValue<T extends object | string | boolean>(
     );
 }
 
-// Board Options
+// Per tab settings
 
 const invisibleFamily = atomFamily((tab: string) => atom(false));
 export const currentInvisibleAtom = tabValue(invisibleFamily);
 
 const tabFamily = atomFamily((tab: string) => atom("info"));
 export const currentTabSelectedAtom = tabValue(tabFamily);
+
+const lichessOptionsFamily = atomFamily((tab: string) => atom<LichessGamesOptions>({
+    ratings: [1000, 1200, 1400, 1600, 1800, 2000, 2200, 2500],
+    speeds: ["bullet", "blitz", "rapid", "classical", "correspondence"],
+}));
+export const currentLichessOptionsAtom = tabValue(lichessOptionsFamily);
 
 // Practice
 

--- a/src/components/common/ToggleButtonGroup.tsx
+++ b/src/components/common/ToggleButtonGroup.tsx
@@ -1,0 +1,45 @@
+import { Button, Stack, Text, Tooltip } from "@mantine/core";
+import { ReactNode } from "react";
+
+interface ToggleButtonGridProps<T> {
+    label: string;
+    options: { content: ReactNode, name: string, value: T, isToggled: boolean }[];
+    includeTooltips?: boolean;
+    toggleOption(option: T): void;
+}
+
+function ToggleButtonGroup<T>(props: ToggleButtonGridProps<T>) {
+    return (
+        //this could use <InputWrapper> for the label instead if updating mantine to 7
+        <Stack justify="flex-start" spacing="xs">
+            <Text weight={500} size="sm">{props.label}</Text>
+            <Button.Group>
+                {props.options.map(option => {
+                    if (props.includeTooltips) {
+                        return (
+                            <Tooltip label={option.name} key={option.name}>
+                                <Button
+                                    variant={option.isToggled ? "filled" : "default"}
+                                    onClick={() => props.toggleOption(option.value)}
+                                >
+                                    {option.content}
+                                </Button>
+                            </Tooltip>
+                        );
+                    } else {
+                        return (
+                            <Button key={option.name}
+                                variant={option.isToggled ? "filled" : "default"}
+                                onClick={() => props.toggleOption(option.value)}
+                            >
+                                {option.content}
+                            </Button>
+                        );
+                    }
+                })}
+            </Button.Group>
+        </Stack>
+    )
+}
+
+export default ToggleButtonGroup;

--- a/src/components/common/ToggleButtonGroup.tsx
+++ b/src/components/common/ToggleButtonGroup.tsx
@@ -11,7 +11,7 @@ interface ToggleButtonGridProps<T> {
 function ToggleButtonGroup<T>(props: ToggleButtonGridProps<T>) {
     return (
         //this could use <InputWrapper> for the label instead if updating mantine to 7
-        <Stack justify="flex-start" spacing="xs">
+        <Stack justify="flex-start" spacing={0}>
             <Text weight={500} size="sm">{props.label}</Text>
             <Button.Group>
                 {props.options.map(option => {

--- a/src/components/common/ToggleButtonGroup.tsx
+++ b/src/components/common/ToggleButtonGroup.tsx
@@ -3,13 +3,32 @@ import { ReactNode } from "react";
 
 interface ToggleButtonGroupProps<T> {
     label: string;
-    options: { content: ReactNode, name: string, value: T, isToggled: boolean }[];
+    options: ToggleButtonGroupOption<T>[];
     includeTooltips?: boolean;
     minButtonWidth?: string;
     toggleOption(option: T): void;
 }
 
+export interface ToggleButtonGroupOption<T> {
+    content: ReactNode,
+    name: string,
+    value: T,
+    isToggled: boolean
+}
+
 function ToggleButtonGroup<T>(props: ToggleButtonGroupProps<T>) {
+
+    const getButton = (option: ToggleButtonGroupOption<T>) => (
+        <Button key={option.name}
+            variant={option.isToggled ? "filled" : "default"}
+            radius={0}
+            onClick={() => props.toggleOption(option.value)}
+            miw={props.minButtonWidth}
+        >
+            {option.content}
+        </Button>
+    );
+
     return (
         //this could use <InputWrapper> for the label instead if updating mantine to 7
         <Stack justify="flex-start" spacing={0}>
@@ -19,27 +38,11 @@ function ToggleButtonGroup<T>(props: ToggleButtonGroupProps<T>) {
                     if (props.includeTooltips) {
                         return (
                             <Tooltip label={option.name} key={option.name}>
-                                <Button
-                                    variant={option.isToggled ? "filled" : "default"}
-                                    radius={0}
-                                    onClick={() => props.toggleOption(option.value)}
-                                    miw={props.minButtonWidth}
-                                >
-                                    {option.content}
-                                </Button>
+                                {getButton(option)}
                             </Tooltip>
                         );
                     } else {
-                        return (
-                            <Button key={option.name}
-                                variant={option.isToggled ? "filled" : "default"}
-                                radius={0}
-                                onClick={() => props.toggleOption(option.value)}
-                                miw={props.minButtonWidth}
-                            >
-                                {option.content}
-                            </Button>
-                        );
+                        return (getButton(option));
                     }
                 })}
             </Group>

--- a/src/components/common/ToggleButtonGroup.tsx
+++ b/src/components/common/ToggleButtonGroup.tsx
@@ -1,7 +1,7 @@
 import { Button, Group, Stack, Text, Tooltip } from "@mantine/core";
 import { ReactNode } from "react";
 
-interface ToggleButtonGridProps<T> {
+interface ToggleButtonGroupProps<T> {
     label: string;
     options: { content: ReactNode, name: string, value: T, isToggled: boolean }[];
     includeTooltips?: boolean;
@@ -9,7 +9,7 @@ interface ToggleButtonGridProps<T> {
     toggleOption(option: T): void;
 }
 
-function ToggleButtonGroup<T>(props: ToggleButtonGridProps<T>) {
+function ToggleButtonGroup<T>(props: ToggleButtonGroupProps<T>) {
     return (
         //this could use <InputWrapper> for the label instead if updating mantine to 7
         <Stack justify="flex-start" spacing={0}>

--- a/src/components/common/ToggleButtonGroup.tsx
+++ b/src/components/common/ToggleButtonGroup.tsx
@@ -1,10 +1,11 @@
-import { Button, Stack, Text, Tooltip } from "@mantine/core";
+import { Button, Group, Stack, Text, Tooltip } from "@mantine/core";
 import { ReactNode } from "react";
 
 interface ToggleButtonGridProps<T> {
     label: string;
     options: { content: ReactNode, name: string, value: T, isToggled: boolean }[];
     includeTooltips?: boolean;
+    minButtonWidth?: string;
     toggleOption(option: T): void;
 }
 
@@ -13,14 +14,16 @@ function ToggleButtonGroup<T>(props: ToggleButtonGridProps<T>) {
         //this could use <InputWrapper> for the label instead if updating mantine to 7
         <Stack justify="flex-start" spacing={0}>
             <Text weight={500} size="sm">{props.label}</Text>
-            <Button.Group>
+            <Group spacing={0}>
                 {props.options.map(option => {
                     if (props.includeTooltips) {
                         return (
                             <Tooltip label={option.name} key={option.name}>
                                 <Button
                                     variant={option.isToggled ? "filled" : "default"}
+                                    radius={0}
                                     onClick={() => props.toggleOption(option.value)}
+                                    miw={props.minButtonWidth}
                                 >
                                     {option.content}
                                 </Button>
@@ -30,14 +33,16 @@ function ToggleButtonGroup<T>(props: ToggleButtonGridProps<T>) {
                         return (
                             <Button key={option.name}
                                 variant={option.isToggled ? "filled" : "default"}
+                                radius={0}
                                 onClick={() => props.toggleOption(option.value)}
+                                miw={props.minButtonWidth}
                             >
                                 {option.content}
                             </Button>
                         );
                     }
                 })}
-            </Button.Group>
+            </Group>
         </Stack>
     )
 }

--- a/src/components/panels/database/DatabasePanel.tsx
+++ b/src/components/panels/database/DatabasePanel.tsx
@@ -72,7 +72,10 @@ async function fetchOpening(query: PositionQuery, db: DBType, tab: string, liche
 function DatabasePanel({ height, fen }: { height: number; fen: string }) {
   const referenceDatabase = useAtomValue(referenceDbAtom);
   const [db, setDb] = useState<"local" | "lch_all" | "lch_master">("local");
-  const [lichessOptions, setLichessOptions] = useState<LichessGamesOptions>({});
+  const [lichessOptions, setLichessOptions] = useState<LichessGamesOptions>({
+    ratings: [1000, 1200, 1400, 1600, 1800, 2000, 2200, 2500],
+    speeds: ["bullet", "blitz", "rapid", "classical", "correspondence"],
+  });
   const [masterOptions, setMasterOptions] = useState<MasterGamesOptions>({});
   const [query, setQuery] = useState<PositionQuery>({ value: fen, type: "exact" });
   const [debouncedFen] = useDebouncedValue(fen, 50);

--- a/src/components/panels/database/DatabasePanel.tsx
+++ b/src/components/panels/database/DatabasePanel.tsx
@@ -1,5 +1,5 @@
 import { Alert, Group, SegmentedControl, Tabs, Text } from "@mantine/core";
-import { memo, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { Opening, PositionQuery, searchPosition } from "@/utils/db";
 import { currentTabAtom, referenceDbAtom } from "@/atoms/atoms";
 import { useAtomValue } from "jotai";
@@ -74,7 +74,12 @@ function DatabasePanel({ height, fen }: { height: number; fen: string }) {
   const [db, setDb] = useState<"local" | "lch_all" | "lch_master">("local");
   const [lichessOptions, setLichessOptions] = useState<LichessGamesOptions>({});
   const [masterOptions, setMasterOptions] = useState<MasterGamesOptions>({});
+  const [query, setQuery] = useState<PositionQuery>({ value: fen, type: "exact" });
   const [debouncedFen] = useDebouncedValue(fen, 50);
+
+  useEffect(() => {
+    setQuery((q) => ({ ...q, value: debouncedFen }));
+  }, [debouncedFen, setQuery]);
 
   const dbType: DBType = match(db)
     .with("local", (v) => {
@@ -86,11 +91,6 @@ function DatabasePanel({ height, fen }: { height: number; fen: string }) {
     .otherwise((v) => ({
       type: v,
     }));
-
-  const [query, setQuery] = useState<PositionQuery>({
-    value: fen,
-    type: "exact",
-  });
 
   const tab = useAtomValue(currentTabAtom);
 

--- a/src/components/panels/database/DatabasePanel.tsx
+++ b/src/components/panels/database/DatabasePanel.tsx
@@ -93,11 +93,17 @@ function DatabasePanel({ height, fen }: { height: number; fen: string }) {
   });
 
   const tab = useAtomValue(currentTabAtom);
+
+  const dbOptionsKey = match(db)
+    .with("local", () => "0")
+    .with("lch_all", () => `1_${JSON.stringify(lichessOptions)}`)
+    .with("lch_master", () => `2_${JSON.stringify(masterOptions)}`)
+    .exhaustive();
   const {
     data: openingData,
     isLoading,
     error,
-  } = useSWR([dbType, query], async ([dbType, query]) => {
+  } = useSWR([dbType, query, dbOptionsKey], async ([dbType, query]) => {
     return fetchOpening(query, dbType, tab?.value || "", lichessOptions, masterOptions);
   });
 
@@ -180,7 +186,7 @@ function DatabasePanel({ height, fen }: { height: number; fen: string }) {
                 options={masterOptions}
                 setOptions={setMasterOptions}
               />
-            ).run()
+            ).exhaustive()
           }
         </PanelWithError>
       </Tabs>

--- a/src/components/panels/database/DatabasePanel.tsx
+++ b/src/components/panels/database/DatabasePanel.tsx
@@ -113,16 +113,8 @@ function DatabasePanel({ height, fen }: { height: number; fen: string }) {
         <SegmentedControl
           data={[
             { label: "Local", value: "local" },
-            {
-              label: "Lichess All",
-              value: "lch_all",
-              disabled: tabType === "options",
-            },
-            {
-              label: "Lichess Masters",
-              value: "lch_master",
-              disabled: tabType === "options",
-            },
+            { label: "Lichess All", value: "lch_all" },
+            { label: "Lichess Masters", value: "lch_master" },
           ]}
           value={db}
           onChange={(value) =>

--- a/src/components/panels/database/SearchPanel.tsx
+++ b/src/components/panels/database/SearchPanel.tsx
@@ -19,12 +19,10 @@ async function similarStructure(fen: string) {
 
 function SearchPanel({
   boardFen,
-  disabled,
   query,
   setQuery,
 }: {
   boardFen: string;
-  disabled: boolean;
   query: PositionQuery;
   setQuery: React.Dispatch<React.SetStateAction<PositionQuery>>;
 }) {
@@ -44,7 +42,6 @@ function SearchPanel({
       <Group>
         <Text fw="bold">Position:</Text>
         <SegmentedControl
-          disabled={disabled}
           data={[
             { value: "exact", label: "Exact" },
             { value: "partial", label: "Partial" },

--- a/src/components/panels/database/SearchPanel.tsx
+++ b/src/components/panels/database/SearchPanel.tsx
@@ -10,7 +10,7 @@ import {
   SegmentedControl,
 } from "@mantine/core";
 import { invoke } from "@tauri-apps/api";
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import { Chessground } from "@/chessground/Chessground";
 
 async function similarStructure(fen: string) {
@@ -27,10 +27,6 @@ function SearchPanel({
   setQuery: React.Dispatch<React.SetStateAction<PositionQuery>>;
 }) {
   const boardRef = useRef(null);
-
-  useEffect(() => {
-    setQuery((q) => ({ ...q, value: boardFen }));
-  }, [boardFen, setQuery]);
 
   const fetchSimilarStructure = async (fen: string) => {
     const fenResult = await similarStructure(fen);

--- a/src/components/panels/database/options/LichessOptionsPanel.tsx
+++ b/src/components/panels/database/options/LichessOptionsPanel.tsx
@@ -13,14 +13,14 @@ interface LichessOptionsPanelProps {
 }
 
 const LichessOptionsPanel = (props: LichessOptionsPanelProps) => {
-    const timeControls: LichessGameSpeed[] = ["ultrabullet", "bullet", "blitz", "rapid", "classical", "correspondence"];
+    const timeControls: LichessGameSpeed[] = ["ultraBullet", "bullet", "blitz", "rapid", "classical", "correspondence"];
     const ratings: LichessRating[] = [0, 1000, 1200, 1400, 1600, 1800, 2000, 2200, 2500];
 
     function mapTimeControl(speed: LichessGameSpeed) {
         const name = `${speed.charAt(0).toUpperCase()}${speed.slice(1)}`;
         //TODO: use lichess icons
         const icon = match(speed)
-            .with("ultrabullet", () => <IconChevronsRight />)
+            .with("ultraBullet", () => <IconChevronsRight />)
             .with("bullet", () => <IconChevronRight />)
             .with("blitz", () => <IconFlame />)
             .with("rapid", () => <IconCarrot />)

--- a/src/components/panels/database/options/LichessOptionsPanel.tsx
+++ b/src/components/panels/database/options/LichessOptionsPanel.tsx
@@ -1,5 +1,5 @@
 import { Stack } from "@mantine/core";
-import ToggleButtonGroup from "@/components/common/ToggleButtonGroup";
+import ToggleButtonGroup, { ToggleButtonGroupOption } from "@/components/common/ToggleButtonGroup";
 import { LichessGameSpeed, LichessGamesOptions, LichessRating } from "@/utils/lichess/lichessexplorer";
 import { match } from "ts-pattern";
 import { IconChevronRight, IconChevronsRight, IconClockHour4, IconFlame, IconHourglassHigh, IconSend } from "@tabler/icons-react";
@@ -14,7 +14,7 @@ const LichessOptionsPanel = (props: LichessOptionsPanelProps) => {
     const timeControls: LichessGameSpeed[] = ["ultraBullet", "bullet", "blitz", "rapid", "classical", "correspondence"];
     const ratings: LichessRating[] = [0, 1000, 1200, 1400, 1600, 1800, 2000, 2200, 2500];
 
-    function mapTimeControl(speed: LichessGameSpeed) {
+    function mapTimeControl(speed: LichessGameSpeed): ToggleButtonGroupOption<LichessGameSpeed> {
         const name = `${speed.charAt(0).toUpperCase()}${speed.slice(1)}`;
         const icon = match(speed)
             .with("ultraBullet", () => <IconChevronsRight />)
@@ -32,7 +32,7 @@ const LichessOptionsPanel = (props: LichessOptionsPanelProps) => {
         };
     }
 
-    function mapRatingOption(rating: LichessRating) {
+    function mapRatingOption(rating: LichessRating): ToggleButtonGroupOption<LichessRating> {
         const name = rating == 0 ? "400" : rating.toString();
         return {
             content: (<span>{name}</span>),

--- a/src/components/panels/database/options/LichessOptionsPanel.tsx
+++ b/src/components/panels/database/options/LichessOptionsPanel.tsx
@@ -13,7 +13,7 @@ interface LichessOptionsPanelProps {
 }
 
 const LichessOptionsPanel = (props: LichessOptionsPanelProps) => {
-    const timeControls: LichessGameSpeed[] = ["ultrabullet", "bullet", "blitz", "rapid", "classical", "correspondence"]
+    const timeControls: LichessGameSpeed[] = ["ultrabullet", "bullet", "blitz", "rapid", "classical", "correspondence"];
     const ratings: LichessRating[] = [0, 1000, 1200, 1400, 1600, 1800, 2000, 2200, 2500];
 
     function mapTimeControl(speed: LichessGameSpeed) {
@@ -26,7 +26,7 @@ const LichessOptionsPanel = (props: LichessOptionsPanelProps) => {
             .with("rapid", () => <IconCarrot />)
             .with("classical", () => <IconAirBalloon />)
             .with("correspondence", () => <IconSend />)
-            .run();
+            .exhaustive();
         return {
             content: icon,
             name: name,

--- a/src/components/panels/database/options/LichessOptionsPanel.tsx
+++ b/src/components/panels/database/options/LichessOptionsPanel.tsx
@@ -46,8 +46,10 @@ const LichessOptionsPanel = (props: LichessOptionsPanelProps) => {
         const selected = props.options.speeds ?? [];
         const newSelected = [...selected];
         const index = newSelected.indexOf(speed);
-        if (index >= 0 && newSelected.length > 1) {
-            newSelected.splice(index, 1);
+        if (index >= 0) {
+            if (newSelected.length > 1) {
+                newSelected.splice(index, 1);
+            }
         } else {
             newSelected.push(speed);
         }
@@ -58,8 +60,10 @@ const LichessOptionsPanel = (props: LichessOptionsPanelProps) => {
         const selected = props.options.ratings ?? [];
         const newSelected = [...selected];
         const index = newSelected.indexOf(rating);
-        if (index >= 0 && newSelected.length > 1) {
-            newSelected.splice(index, 1);
+        if (index >= 0) {
+            if (newSelected.length > 1) {
+                newSelected.splice(index, 1);
+            }
         } else {
             newSelected.push(rating);
         }

--- a/src/components/panels/database/options/LichessOptionsPanel.tsx
+++ b/src/components/panels/database/options/LichessOptionsPanel.tsx
@@ -1,0 +1,97 @@
+import {
+    Stack,
+  } from "@mantine/core";
+import ToggleButtonGroup from "@/components/common/ToggleButtonGroup";
+import { LichessGameSpeed, LichessGamesOptions, LichessRating } from "@/utils/lichess/lichessexplorer";
+import { match } from "ts-pattern";
+import { IconAirBalloon, IconCarrot, IconChevronRight, IconChevronsRight, IconFlame, IconSend } from "@tabler/icons-react";
+import { MonthPickerInput } from "@mantine/dates";
+
+interface LichessOptionsPanelProps {
+    options: LichessGamesOptions;
+    setOptions(options: LichessGamesOptions): void;
+}
+
+const LichessOptionsPanel = (props: LichessOptionsPanelProps) => {
+    const timeControls: LichessGameSpeed[] = ["ultrabullet", "bullet", "blitz", "rapid", "classical", "correspondence"]
+    const ratings: LichessRating[] = [0, 1000, 1200, 1400, 1600, 1800, 2000, 2200, 2500];
+
+    function mapTimeControl(speed: LichessGameSpeed) {
+        const name = `${speed.charAt(0).toUpperCase()}${speed.slice(1)}`;
+        //TODO: use lichess icons
+        const icon = match(speed)
+            .with("ultrabullet", () => <IconChevronsRight />)
+            .with("bullet", () => <IconChevronRight />)
+            .with("blitz", () => <IconFlame />)
+            .with("rapid", () => <IconCarrot />)
+            .with("classical", () => <IconAirBalloon />)
+            .with("correspondence", () => <IconSend />)
+            .run();
+        return {
+            content: icon,
+            name: name,
+            value: speed,
+            isToggled: (props.options.speeds ?? []).some(s => s === speed)
+        };
+    }
+
+    function mapRatingOption(rating: LichessRating) {
+        const name = rating == 0 ? "400" : rating.toString();
+        return {
+            content: (<span>{name}</span>),
+            name: name,
+            value: rating,
+            isToggled: (props.options.ratings ?? []).some(r => r === rating)
+        };
+    }
+
+    function toggleTimeControl(speed: LichessGameSpeed) {
+        const selected = props.options.speeds ?? [];
+        const newSelected = [...selected];
+        const index = newSelected.indexOf(speed);
+        if (index >= 0) {
+            newSelected.splice(index, 1);
+        } else {
+            newSelected.push(speed);
+        }
+        props.setOptions({...props.options, speeds: newSelected});
+    }
+
+    function toggleRating(rating: LichessRating) {
+        const selected = props.options.ratings ?? [];
+        const newSelected = [...selected];
+        const index = newSelected.indexOf(rating);
+        if (index >= 0) {
+            newSelected.splice(index, 1);
+        } else {
+            newSelected.push(rating);
+        }
+        props.setOptions({...props.options, ratings: newSelected});
+    }
+
+    const setSince = (date: Date | null | undefined) => props.setOptions({...props.options, since: date ?? undefined});
+    const setUntil = (date: Date | null | undefined) => props.setOptions({...props.options, until: date ?? undefined});
+
+    return (
+        <Stack justify="flex-start">
+            <ToggleButtonGroup label="Time control"
+                options={timeControls.map(mapTimeControl)}
+                toggleOption={toggleTimeControl} includeTooltips />
+            <ToggleButtonGroup label="Average rating"
+                options={ratings.map(mapRatingOption)}
+                toggleOption={toggleRating} />
+            <MonthPickerInput label="Since"
+                placeholder="Pick date"
+                value={props.options.since}
+                onChange={setSince}
+                clearable />
+            <MonthPickerInput label="Until"
+                placeholder="Pick date"
+                value={props.options.until}
+                onChange={setUntil}
+                clearable />
+        </Stack>
+    );
+}
+
+export default LichessOptionsPanel;

--- a/src/components/panels/database/options/LichessOptionsPanel.tsx
+++ b/src/components/panels/database/options/LichessOptionsPanel.tsx
@@ -1,6 +1,4 @@
-import {
-    Stack,
-  } from "@mantine/core";
+import { Stack } from "@mantine/core";
 import ToggleButtonGroup from "@/components/common/ToggleButtonGroup";
 import { LichessGameSpeed, LichessGamesOptions, LichessRating } from "@/utils/lichess/lichessexplorer";
 import { match } from "ts-pattern";
@@ -69,9 +67,6 @@ const LichessOptionsPanel = (props: LichessOptionsPanelProps) => {
         props.setOptions({...props.options, ratings: newSelected});
     }
 
-    const setSince = (date: Date | null | undefined) => props.setOptions({...props.options, since: date ?? undefined});
-    const setUntil = (date: Date | null | undefined) => props.setOptions({...props.options, until: date ?? undefined});
-
     return (
         <Stack justify="flex-start">
             <ToggleButtonGroup label="Time control"
@@ -82,13 +77,13 @@ const LichessOptionsPanel = (props: LichessOptionsPanelProps) => {
                 toggleOption={toggleRating} />
             <MonthPickerInput label="Since"
                 placeholder="Pick date"
-                value={props.options.since}
-                onChange={setSince}
+                value={props.options.since ?? null}
+                onChange={value => props.setOptions({...props.options, since: value ?? undefined})}
                 clearable />
             <MonthPickerInput label="Until"
                 placeholder="Pick date"
-                value={props.options.until}
-                onChange={setUntil}
+                value={props.options.until ?? null}
+                onChange={value => props.setOptions({...props.options, until: value ?? undefined})}
                 clearable />
         </Stack>
     );

--- a/src/components/panels/database/options/LichessOptionsPanel.tsx
+++ b/src/components/panels/database/options/LichessOptionsPanel.tsx
@@ -70,10 +70,13 @@ const LichessOptionsPanel = (props: LichessOptionsPanelProps) => {
         <Stack justify="flex-start">
             <ToggleButtonGroup label="Time control"
                 options={timeControls.map(mapTimeControl)}
-                toggleOption={toggleTimeControl} includeTooltips />
+                toggleOption={toggleTimeControl}
+                minButtonWidth="9ch"
+                includeTooltips />
             <ToggleButtonGroup label="Average rating"
                 options={ratings.map(mapRatingOption)}
-                toggleOption={toggleRating} />
+                toggleOption={toggleRating}
+                minButtonWidth="9ch" />
             <MonthPickerInput label="Since"
                 placeholder="Pick date"
                 value={props.options.since ?? null}

--- a/src/components/panels/database/options/LichessOptionsPanel.tsx
+++ b/src/components/panels/database/options/LichessOptionsPanel.tsx
@@ -2,7 +2,7 @@ import { Stack } from "@mantine/core";
 import ToggleButtonGroup from "@/components/common/ToggleButtonGroup";
 import { LichessGameSpeed, LichessGamesOptions, LichessRating } from "@/utils/lichess/lichessexplorer";
 import { match } from "ts-pattern";
-import { IconAirBalloon, IconCarrot, IconChevronRight, IconChevronsRight, IconFlame, IconSend } from "@tabler/icons-react";
+import { IconChevronRight, IconChevronsRight, IconClockHour4, IconFlame, IconHourglassHigh, IconSend } from "@tabler/icons-react";
 import { MonthPickerInput } from "@mantine/dates";
 
 interface LichessOptionsPanelProps {
@@ -16,13 +16,12 @@ const LichessOptionsPanel = (props: LichessOptionsPanelProps) => {
 
     function mapTimeControl(speed: LichessGameSpeed) {
         const name = `${speed.charAt(0).toUpperCase()}${speed.slice(1)}`;
-        //TODO: use lichess icons
         const icon = match(speed)
             .with("ultraBullet", () => <IconChevronsRight />)
             .with("bullet", () => <IconChevronRight />)
             .with("blitz", () => <IconFlame />)
-            .with("rapid", () => <IconCarrot />)
-            .with("classical", () => <IconAirBalloon />)
+            .with("rapid", () => <IconHourglassHigh />)
+            .with("classical", () => <IconClockHour4 />)
             .with("correspondence", () => <IconSend />)
             .exhaustive();
         return {

--- a/src/components/panels/database/options/LichessOptionsPanel.tsx
+++ b/src/components/panels/database/options/LichessOptionsPanel.tsx
@@ -46,7 +46,7 @@ const LichessOptionsPanel = (props: LichessOptionsPanelProps) => {
         const selected = props.options.speeds ?? [];
         const newSelected = [...selected];
         const index = newSelected.indexOf(speed);
-        if (index >= 0) {
+        if (index >= 0 && newSelected.length > 1) {
             newSelected.splice(index, 1);
         } else {
             newSelected.push(speed);
@@ -58,7 +58,7 @@ const LichessOptionsPanel = (props: LichessOptionsPanelProps) => {
         const selected = props.options.ratings ?? [];
         const newSelected = [...selected];
         const index = newSelected.indexOf(rating);
-        if (index >= 0) {
+        if (index >= 0 && newSelected.length > 1) {
             newSelected.splice(index, 1);
         } else {
             newSelected.push(rating);

--- a/src/components/panels/database/options/MastersOptionsPanel.tsx
+++ b/src/components/panels/database/options/MastersOptionsPanel.tsx
@@ -1,6 +1,6 @@
 import { MasterGamesOptions } from "@/utils/lichess/lichessexplorer";
 import { Stack } from "@mantine/core";
-import { MonthPickerInput } from "@mantine/dates";
+import { YearPickerInput } from "@mantine/dates";
 
 interface MasterOptionsPanelProps {
     options: MasterGamesOptions;
@@ -8,15 +8,15 @@ interface MasterOptionsPanelProps {
 }
 
 const MasterOptionsPanel = (props: MasterOptionsPanelProps) => {
-    
+
     return (
         <Stack justify="flex-start">
-            <MonthPickerInput label="Since"
+            <YearPickerInput label="Since"
                 placeholder="Pick date"
                 value={props.options.since ?? null}
                 onChange={value => props.setOptions({...props.options, since: value ?? undefined})}
                 clearable />
-            <MonthPickerInput label="Until"
+            <YearPickerInput label="Until"
                 placeholder="Pick date"
                 value={props.options.until ?? null}
                 onChange={value => props.setOptions({...props.options, until: value ?? undefined})}

--- a/src/components/panels/database/options/MastersOptionsPanel.tsx
+++ b/src/components/panels/database/options/MastersOptionsPanel.tsx
@@ -1,0 +1,31 @@
+import { MasterGamesOptions } from "@/utils/lichess/lichessexplorer";
+import { Stack } from "@mantine/core";
+import { MonthPickerInput } from "@mantine/dates";
+
+interface MasterOptionsPanelProps {
+    options: MasterGamesOptions;
+    setOptions(options: MasterGamesOptions): void;
+}
+
+const MasterOptionsPanel = (props: MasterOptionsPanelProps) => {
+
+    const setSince = (date: Date | null | undefined) => props.setOptions({...props.options, since: date ?? undefined});
+    const setUntil = (date: Date | null | undefined) => props.setOptions({...props.options, until: date ?? undefined});
+
+    return (
+        <Stack justify="flex-start">
+            <MonthPickerInput label="Since"
+                placeholder="Pick date"
+                value={props.options.since}
+                onChange={setSince}
+                clearable />
+            <MonthPickerInput label="Until"
+                placeholder="Pick date"
+                value={props.options.until}
+                onChange={setUntil}
+                clearable />
+        </Stack>
+    );
+}
+
+export default MasterOptionsPanel;

--- a/src/components/panels/database/options/MastersOptionsPanel.tsx
+++ b/src/components/panels/database/options/MastersOptionsPanel.tsx
@@ -8,21 +8,18 @@ interface MasterOptionsPanelProps {
 }
 
 const MasterOptionsPanel = (props: MasterOptionsPanelProps) => {
-
-    const setSince = (date: Date | null | undefined) => props.setOptions({...props.options, since: date ?? undefined});
-    const setUntil = (date: Date | null | undefined) => props.setOptions({...props.options, until: date ?? undefined});
-
+    
     return (
         <Stack justify="flex-start">
             <MonthPickerInput label="Since"
                 placeholder="Pick date"
-                value={props.options.since}
-                onChange={setSince}
+                value={props.options.since ?? null}
+                onChange={value => props.setOptions({...props.options, since: value ?? undefined})}
                 clearable />
             <MonthPickerInput label="Until"
                 placeholder="Pick date"
-                value={props.options.until}
-                onChange={setUntil}
+                value={props.options.until ?? null}
+                onChange={value => props.setOptions({...props.options, until: value ?? undefined})}
                 clearable />
         </Stack>
     );

--- a/src/utils/lichess.tsx
+++ b/src/utils/lichess.tsx
@@ -199,7 +199,7 @@ export async function getCloudEvaluation(fen: string, multipv = 1) {
 }
 
 export async function getLichessGames(fen: string, options?: LichessGamesOptions): Promise<PositionData> {
-  let url = `${explorerURL}/lichess?fen=${fen}`;
+  let url = `${explorerURL}/lichess?fen=${encodeURIComponent(fen)}`;
   const queryParams = getLichessGamesQueryParams(options);
   if (queryParams.length > 0) {
     url += `&${queryParams.join('&')}`;
@@ -208,12 +208,12 @@ export async function getLichessGames(fen: string, options?: LichessGamesOptions
 }
 
 export async function getMasterGames(fen: string, options?: MasterGamesOptions): Promise<PositionData> {
-  let url = `${explorerURL}/masters?fen=${fen}`;
+  let url = `${explorerURL}/masters?fen=${encodeURIComponent(fen)}`;
   const queryParams = getMasterGamesQueryParams(options);
   if (queryParams.length > 0) {
       url += `&${queryParams.join('&')}`;
   }
-  return (await fetch<PositionData>(`${explorerURL}/masters?fen=${fen}`)).data;
+  return (await fetch<PositionData>(url)).data;
 }
 
 export async function getPlayerGames(

--- a/src/utils/lichess.tsx
+++ b/src/utils/lichess.tsx
@@ -8,6 +8,7 @@ import { parsePGN } from "./chess";
 import { countMainPly } from "./treeReducer";
 import { fetch, Response, ResponseType } from "@tauri-apps/api/http";
 import { error } from "tauri-plugin-log-api";
+import { LichessGamesOptions, MasterGamesOptions, getLichessGamesQueryParams, getMasterGamesQueryParams } from "./lichess/lichessexplorer";
 
 const baseURL = "https://lichess.org/api";
 const explorerURL = "https://explorer.lichess.ovh";
@@ -197,11 +198,21 @@ export async function getCloudEvaluation(fen: string, multipv = 1) {
   return fetch(url);
 }
 
-export async function getLichessGames(fen: string): Promise<PositionData> {
-  return (await fetch<PositionData>(`${explorerURL}/lichess?fen=${fen}`)).data;
+export async function getLichessGames(fen: string, options?: LichessGamesOptions): Promise<PositionData> {
+  let url = `${explorerURL}/lichess?fen=${fen}`;
+  const queryParams = getLichessGamesQueryParams(options);
+  if (queryParams.length > 0) {
+    url += `&${queryParams.join('&')}`;
+  }
+  return (await fetch<PositionData>(url)).data;
 }
 
-export async function getMasterGames(fen: string): Promise<PositionData> {
+export async function getMasterGames(fen: string, options?: MasterGamesOptions): Promise<PositionData> {
+  let url = `${explorerURL}/masters?fen=${fen}`;
+  const queryParams = getMasterGamesQueryParams(options);
+  if (queryParams.length > 0) {
+      url += `&${queryParams.join('&')}`;
+  }
   return (await fetch<PositionData>(`${explorerURL}/masters?fen=${fen}`)).data;
 }
 

--- a/src/utils/lichess/lichessexplorer.ts
+++ b/src/utils/lichess/lichessexplorer.ts
@@ -19,6 +19,9 @@ export type MasterGamesOptions = {
 }
 
 export function getLichessGamesQueryParams(options: LichessGamesOptions | undefined): string[] {
+    const getDateQueryString = (date: Date) => 
+        `${date.getFullYear()}-${date.getMonth() + 1}`;
+
     const queryParams: string[] = [];
     if (options) {
         if (options.variant)
@@ -42,6 +45,8 @@ export function getLichessGamesQueryParams(options: LichessGamesOptions | undefi
 }
 
 export function getMasterGamesQueryParams(options: MasterGamesOptions | undefined): string[] {
+    const getDateQueryString = (date: Date) => date.getFullYear().toString();
+
     const queryParams: string[] = [];
     if (options) {
         if (options.since)
@@ -54,10 +59,6 @@ export function getMasterGamesQueryParams(options: MasterGamesOptions | undefine
             queryParams.push(`topGames=${options.topGames}`);
     }
     return queryParams;
-}
-
-function getDateQueryString(date: Date) {
-    return `${date.getFullYear()}-${date.getMonth() + 1}`;
 }
 
 export type LichessVariant = 

--- a/src/utils/lichess/lichessexplorer.ts
+++ b/src/utils/lichess/lichessexplorer.ts
@@ -73,7 +73,7 @@ export type LichessVariant =
     "fromPosition";
 
 export type LichessGameSpeed =
-    "ultrabullet" |
+    "ultraBullet" |
     "bullet" |
     "blitz" |
     "rapid" |

--- a/src/utils/lichess/lichessexplorer.ts
+++ b/src/utils/lichess/lichessexplorer.ts
@@ -1,0 +1,92 @@
+export type LichessGamesOptions = {
+    //https://lichess.org/api#tag/Opening-Explorer/operation/openingExplorerLichess
+    variant?: LichessVariant;
+    speeds?: LichessGameSpeed[];
+    ratings?: LichessRating[];
+    since?: Date;
+    until?: Date;
+    moves?: number;
+    topGames?: number;
+    recentGames?: number;
+}
+
+export type MasterGamesOptions = {
+    //https://lichess.org/api#tag/Opening-Explorer/operation/openingExplorerMaster
+    since?: Date;
+    until?: Date;
+    moves?: number;
+    topGames?: number;
+}
+
+export function getLichessGamesQueryParams(options: LichessGamesOptions | undefined): string[] {
+    const queryParams: string[] = [];
+    if (options) {
+        if (options.variant)
+            queryParams.push(`variant=${options.variant}`);
+        if (options.speeds && options.speeds.length > 0)
+            queryParams.push(`speeds=${options.speeds.join(',')}`);
+        if (options.ratings && options.ratings.length > 0)
+            queryParams.push(`ratings=${options.ratings.join(',')}`);
+        if (options.since)
+            queryParams.push(`since=${getDateQueryString(options.since)}`);
+        if (options.until)
+            queryParams.push(`until=${getDateQueryString(options.until)}`);
+        if (options.moves != undefined && 0 <= options.moves)
+            queryParams.push(`moves=${options.moves}`);
+        if (options.topGames != undefined && 0 <= options.topGames && options.topGames <= 4)
+            queryParams.push(`topGames=${options.topGames}`);
+        if (options.recentGames != undefined && 0 <= options.recentGames && options.recentGames <= 4)
+            queryParams.push(`recentGames=${options.recentGames}`)
+    }
+    return queryParams;
+}
+
+export function getMasterGamesQueryParams(options: MasterGamesOptions | undefined): string[] {
+    const queryParams: string[] = [];
+    if (options) {
+        if (options.since)
+            queryParams.push(`since=${getDateQueryString(options.since)}`);
+        if (options.until)
+            queryParams.push(`until=${getDateQueryString(options.until)}`);
+        if (options.moves != undefined && 0 <= options.moves)
+            queryParams.push(`moves=${options.moves}`);
+        if (options.topGames != undefined && 0 <= options.topGames && options.topGames <= 15)
+            queryParams.push(`topGames=${options.topGames}`);
+    }
+    return queryParams;
+}
+
+function getDateQueryString(date: Date) {
+    return `${date.getFullYear()}-${date.getMonth() + 1}`;
+}
+
+export type LichessVariant = 
+    "standard" |
+    "chess960" |
+    "crazyhouse" |
+    "antichess" |
+    "atomic" |
+    "horde" |
+    "kingOfTheHill" |
+    "racingKings" |
+    "threeCheck" |
+    "fromPosition";
+
+export type LichessGameSpeed =
+    "ultrabullet" |
+    "bullet" |
+    "blitz" |
+    "rapid" |
+    "classical" |
+    "correspondence";
+
+export type LichessRating =
+    0 |
+    1000 |
+    1200 |
+    1400 |
+    1600 |
+    1800 |
+    2000 |
+    2200 |
+    2500;


### PR DESCRIPTION
Adding the same lichess / lichess masters DB options that are available on the lichess website. Note there are some other options (topGames / recentGames) which could be set via the api as well but I didn't add UI controls for them.

**Lichess DB:**
![image](https://github.com/franciscoBSalgueiro/en-croissant/assets/25903992/9ae0b091-08e4-492f-b12e-819be4c336c4)

**Masters DB:**
![image](https://github.com/franciscoBSalgueiro/en-croissant/assets/25903992/0561713a-d610-455d-9d6e-2facde341a4e)

Possible issues:
- `Text` Label on `ToggleButtonGroup` is not quite consistent with the labels `mantine` places on inputs (e.g. on the `MonthPickerInput`), it would be nicer to use `InputWrapper` for this but that needs `@mantine/core` to be updated to v7, may cause issues elsewhere
- Time control icons are not the same as lichess icons, I think in general they are sensible enough though and have tooltips so maybe not a very significant issue. Could use the lichess icon font from here but it would be more effort to make it consistent with the icons used elsewhere: https://github.com/lichess-org/lila/tree/master/public/font
- Maybe should have a debounce function for fetching data, so that toggling a bunch of options at once doesn't fire a request for each change
- Lack of persistence of options if changing between tabs (e.g. change from Database tab to Annotate, then back to Database) - this affects more than just these options though so hesitant to make changes just for these. Likely needs a larger change to state management