### PR TITLE
In debug build: include sourcemap, don't minify JS

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react-swc'
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import { resolve } from 'node:path'
 
+const isDebug: boolean = !!process.env.TAURI_DEBUG;
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), vanillaExtractPlugin()],
@@ -10,6 +12,8 @@ export default defineConfig({
     port: 1420
   },
   build: {
+    minify: isDebug ? false : 'esbuild',
+    sourcemap: isDebug ? 'inline' : false,
     rollupOptions: {
       output: {
         entryFileNames: `assets/[name].js`,


### PR DESCRIPTION
Small change to make debugging the typescript code easier, when building in `--debug` mode include sourcemap and don't minify JS