### PR TITLE
Analysis/Logs panel errors when no engines are configured

### DIFF
--- a/src/components/panels/analysis/AnalysisPanel.tsx
+++ b/src/components/panels/analysis/AnalysisPanel.tsx
@@ -78,21 +78,23 @@ function AnalysisPanel({
       <Tabs.List>
         <Tabs.Tab value="engines">Engines</Tabs.Tab>
         <Tabs.Tab value="report">Report</Tabs.Tab>
-        <Tabs.Tab value="logs">Logs</Tabs.Tab>
+        <Tabs.Tab value="logs" disabled={loadedEngines.length == 0}>Logs</Tabs.Tab>
       </Tabs.List>
       <Tabs.Panel value="engines" pt="xs">
         <ScrollArea sx={{ height: boardSize / 2 }} offsetScrollbars>
-          <Group>
-            <Button
-              rightIcon={
-                allEnabled ? <IconPlayerPause /> : <IconChevronsRight />
-              }
-              variant={allEnabled ? "filled" : "default"}
-              onClick={() => enable(!allEnabled)}
-            >
-              {allEnabled ? "Stop All" : "Run All"}
-            </Button>
-          </Group>
+          {loadedEngines.length > 0 &&
+            <Group>
+              <Button
+                rightIcon={
+                    allEnabled ? <IconPlayerPause /> : <IconChevronsRight />
+                }
+                variant={allEnabled ? "filled" : "default"}
+                onClick={() => enable(!allEnabled)}
+                >
+                {allEnabled ? "Stop All" : "Run All"}
+              </Button>
+            </Group>
+          }
           <Stack mt="sm">
             <Accordion
               variant="separated"

--- a/src/components/panels/analysis/LogsPanel.tsx
+++ b/src/components/panels/analysis/LogsPanel.tsx
@@ -14,17 +14,18 @@ import { forwardRef, useEffect, useMemo, useRef, useState } from "react";
 import useSWR from "swr";
 import { FixedSizeList } from "react-window";
 import { commands } from "@/bindings";
+import { Engine } from "@/utils/engines";
 
 export default function LogsPanel() {
   const engines = useAtomValue(enginesAtom);
-  const [engine, setEngine] = useState(engines.filter((e) => e.loaded)[0]);
+  const [engine, setEngine] = useState<Engine | undefined>(engines.filter((e) => e.loaded)[0]);
 
   const viewport = useRef<HTMLDivElement>(null);
   const activeTab = useAtomValue(activeTabAtom);
   const { data, mutate } = useSWR(
-    ["logs", engine.path, activeTab],
+    ["logs", engine?.path, activeTab],
     async () => {
-      return unwrap(await commands.getEngineLogs(engine.path, activeTab!));
+      return engine ? unwrap(await commands.getEngineLogs(engine.path, activeTab!)) : undefined;
     }
   );
 
@@ -65,7 +66,7 @@ export default function LogsPanel() {
           ]}
         />
         <Select
-          value={engine.name}
+          value={engine?.name ?? "No engines installed"}
           onChange={(name: string) =>
             setEngine(engines.find((e) => e.name === name)!)
           }
@@ -75,7 +76,7 @@ export default function LogsPanel() {
 
       {filteredData?.length === 0 && (
         <Text align="center" mt="lg">
-          No logs for {engine.name}
+          No logs for {engine?.name ?? "engine"}
         </Text>
       )}
       <FixedSizeList

--- a/src/components/panels/analysis/LogsPanel.tsx
+++ b/src/components/panels/analysis/LogsPanel.tsx
@@ -66,7 +66,7 @@ export default function LogsPanel() {
           ]}
         />
         <Select
-          value={engine?.name ?? "No engines installed"}
+          value={engine?.name ?? "No engines loaded"}
           onChange={(name: string) =>
             setEngine(engines.find((e) => e.name === name)!)
           }


### PR DESCRIPTION
![image](https://github.com/franciscoBSalgueiro/en-croissant/assets/25903992/3bb30182-865c-4d45-b50f-4e16aa790102)

### Reproduction steps:
- Remove all configured engines
- Restart en-croissant
- Go to Analysis Board -> Analysis tab
- Errors as there are no engines so `LogPanel` `engine` is undefined