### PR TITLE
Prevent no tabs state

### DIFF
--- a/src/components/tabs/BoardsPage.tsx
+++ b/src/components/tabs/BoardsPage.tsx
@@ -15,7 +15,7 @@ import { TreeStateProvider } from "../common/TreeStateContext";
 import Puzzles from "../puzzles/Puzzles";
 import { BoardTab } from "./BoardTab";
 import NewTabHome from "./NewTabHome";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { useAtom } from "jotai";
 import { activeTabAtom, tabsAtom } from "@/atoms/atoms";
 import ConfirmChangesModal from "./ConfirmChangesModal";
@@ -44,6 +44,16 @@ export default function BoardsPage() {
   const [tabs, setTabs] = useAtom(tabsAtom);
   const [activeTab, setActiveTab] = useAtom(activeTabAtom);
   const [saveModalOpened, toggleSaveModal] = useToggle();
+
+  useEffect(() => {
+    if (tabs.length == 0) {
+      createTab({
+        tab: { name: "New Tab", type: "new" },
+        setTabs,
+        setActiveTab,
+      });
+    }
+  }, [tabs]);
 
   const closeTab = useCallback(
     async (value: string | null, forced?: boolean) => {


### PR DESCRIPTION
When you close the only open tab, you get this blank screen:

![image](https://github.com/franciscoBSalgueiro/en-croissant/assets/25903992/15d01a59-09a1-48db-bc16-c4b8bbaa2954)

The only action the user can take is to open a new tab again, so it makes sense to instead revert it back to the inital state of having the default new tab open if you close the only tab
Maybe this could happen as part of `closeTab` rather than in a `useEffect` afterwards though

Added because the blank state sounded like it caused some confusion in issue https://github.com/franciscoBSalgueiro/en-croissant/issues/3

> Also I noticed a GUI glitch that after playing a game against an engine I cannot get the home screen or play screen to re-display properly (just blank). It appears some user interface element is not getting reset properly.