### PR TITLE
Bug: get lichess game doesn't handle non UTF-8 text in PGN

### DIFF
--- a/src/utils/lichess.tsx
+++ b/src/utils/lichess.tsx
@@ -234,10 +234,9 @@ export async function downloadLichess(
 }
 
 export async function getLichessGame(gameId: string): Promise<string> {
-  return (
-    await fetch<string>(`https://lichess.org/game/export/${gameId}`, {
-      method: "GET",
-      responseType: ResponseType.Text,
-    })
-  ).data;
+  const response = await window.fetch(`https://lichess.org/game/export/${gameId}`);
+  if (!response.ok) {
+    throw new Error(`Failed to load lichess game ${gameId} - ${response.statusText}`);
+  }
+  return await response.text();
 }


### PR DESCRIPTION
![image](https://github.com/franciscoBSalgueiro/en-croissant/assets/25903992/8a7965e1-e6e0-4e70-917d-1a01215a3573)

### Steps to reproduce:
- Import game from FEN `r1bqk2r/pppp1ppp/2n2n2/8/1bB1P3/2N2N2/PB3PPP/R2QK2R w KQkq - 3 8`
- Go to database -> Lichess masters to start loading games
- It will error as one of the PGNs loaded contains non UTF-8 text (game ID `ZJgjwtYR` - one of the player's names contains accented `í`)

I couldn't find any way to change what character encoding is used here, I am not familiar with rust or tauri though so maybe there is some way to do it. This change just uses the webview to fetch instead, it would be nicer to fix it properly though if you have any ideas