### PR TITLE
Add eval chart

### DIFF
--- a/src/components/boards/BoardAnalysis.tsx
+++ b/src/components/boards/BoardAnalysis.tsx
@@ -182,9 +182,6 @@ function BoardAnalysis() {
               notationExpanded={notationExpanded}
               topBar
             />
-            <Paper withBorder p="md">
-              <EvalChart isAnalysing={inProgress} startAnalysis={() => toggleReportingMode()} />
-            </Paper>
             <MoveControls />
           </Stack>
         </>

--- a/src/components/boards/BoardAnalysis.tsx
+++ b/src/components/boards/BoardAnalysis.tsx
@@ -1,4 +1,4 @@
-import { Stack, Tabs } from "@mantine/core";
+import { Paper, Stack, Tabs } from "@mantine/core";
 import { useHotkeys, useToggle } from "@mantine/hooks";
 import {
   IconDatabase,
@@ -33,6 +33,7 @@ import {
   currentTabSelectedAtom,
 } from "@/atoms/atoms";
 import { saveToFile } from "@/utils/tabs";
+import EvalChart from "../common/EvalChart";
 
 function BoardAnalysis() {
   const [editingMode, toggleEditingMode] = useToggle();
@@ -181,6 +182,9 @@ function BoardAnalysis() {
               notationExpanded={notationExpanded}
               topBar
             />
+            <Paper withBorder p="md">
+              <EvalChart isAnalysing={inProgress} startAnalysis={() => toggleReportingMode()} />
+            </Paper>
             <MoveControls />
           </Stack>
         </>

--- a/src/components/common/EvalChart.tsx
+++ b/src/components/common/EvalChart.tsx
@@ -116,7 +116,7 @@ const EvalChart = (props: EvalChartProps) => {
         if (dataMin >= 0) return 1;
         
         return dataMax / (dataMax - dataMin);
-    };
+    }
 
     const CustomTooltip = ({ active, payload }: any) => {
         if (active && payload && payload.length && payload[0].payload) {
@@ -177,9 +177,9 @@ const EvalChart = (props: EvalChartProps) => {
                             </linearGradient>
                         </defs>
                         {currentPositionName &&
-                            <ReferenceLine x={currentPositionName} stroke="#ff9933" />
+                            <ReferenceLine x={currentPositionName} stroke={theme.colors[theme.primaryColor][7]} />
                         }
-                        <Area type="linear" dataKey="yValue" stroke="#ff9933" fill="url(#splitColor)" />
+                        <Area type="linear" dataKey="yValue" stroke={theme.colors[theme.primaryColor][7]} fill="url(#splitColor)" />
                         <Area type="linear" dataKey="altValue" stroke="#999999" strokeDasharray="3 3" activeDot={false} />
                     </AreaChart>
                 </ResponsiveContainer>

--- a/src/components/common/EvalChart.tsx
+++ b/src/components/common/EvalChart.tsx
@@ -1,18 +1,17 @@
 import { useContext } from "react";
 import { TreeDispatchContext, TreeStateContext } from "./TreeStateContext";
 import { Box, LoadingOverlay, createStyles } from "@mantine/core";
-import { ActionIcon, Divider, Group, Stack, Tooltip as MantineTooltip, Text } from "@mantine/core"
+import { Stack } from "@mantine/core"
 import { ResponsiveContainer, Tooltip as RechartsTooltip, AreaChart, Area, XAxis, YAxis, ReferenceLine } from "recharts";
 import { ListNode, TreeNode, treeIteratorMainLine } from "@/utils/treeReducer";
 import { ANNOTATION_INFO } from "@/utils/chess";
 import { formatScore } from "@/utils/score";
 import { arrayEquals, skipWhile, takeWhile } from "@/utils/helperFunctions";
-import { IconRefresh } from "@tabler/icons-react"
 import { Chess } from "chess.js";
 
 interface EvalChartProps {
-    isAnalysing?: boolean;
-    startAnalysis?(): void;
+    isAnalysing: boolean;
+    startAnalysis: () => void;
 }
 
 type DataPoint = {
@@ -148,21 +147,6 @@ const EvalChart = (props: EvalChartProps) => {
     
     return (
         <Stack>
-            <Stack>
-                <Group position="apart">
-                    <Text fz="sm">Engine analysis</Text>
-                    <Group spacing="sm">
-                        {props.startAnalysis != undefined &&
-                            <MantineTooltip label="Analyse game">
-                                <ActionIcon onClick={props.startAnalysis} disabled={props.isAnalysing}>
-                                    <IconRefresh size={15} /> 
-                                </ActionIcon>
-                            </MantineTooltip>
-                        }
-                    </Group>
-                </Group>
-                <Divider />
-            </Stack>
             <Box pos="relative">
                 <LoadingOverlay visible={props.isAnalysing == true} />
                 <ResponsiveContainer width="99%" height={220}>

--- a/src/components/common/EvalChart.tsx
+++ b/src/components/common/EvalChart.tsx
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 import { TreeDispatchContext, TreeStateContext } from "./TreeStateContext";
-import { Box, LoadingOverlay, useMantineColorScheme } from "@mantine/core";
+import { Box, LoadingOverlay, createStyles } from "@mantine/core";
 import { ActionIcon, Divider, Group, Stack, Tooltip as MantineTooltip, Text } from "@mantine/core"
 import { ResponsiveContainer, Tooltip as RechartsTooltip, AreaChart, Area, XAxis, YAxis, ReferenceLine } from "recharts";
 import { ListNode, TreeNode, treeIteratorMainLine } from "@/utils/treeReducer";
@@ -23,10 +23,26 @@ type DataPoint = {
     movePath: number[];
 }
 
+const useStyles = createStyles(theme => ({
+    tooltip: {
+        margin: 0,
+        padding: 5,
+        backgroundColor: theme.colorScheme === 'light' ? 'white' : theme.colors.dark[3],
+        color: theme.colorScheme === 'light' ? 'black': 'white',
+        opacity: 0.8,
+        border: '1px solid #ccc',
+        whiteSpace: 'nowrap',
+    },
+    tooltipTitle: {
+        fontWeight: 'bold'
+    }
+}));
+
 const EvalChart = (props: EvalChartProps) => {
     const { root, position } = useContext(TreeStateContext);
     const dispatch = useContext(TreeDispatchContext);
-    const { colorScheme } = useMantineColorScheme();
+    const { classes, theme } = useStyles();
+    const isLightTheme = theme.colorScheme == 'light';
 
     function getYValue(node: TreeNode): number | undefined {
         if (node.score) {
@@ -105,16 +121,9 @@ const EvalChart = (props: EvalChartProps) => {
     const CustomTooltip = ({ active, payload }: any) => {
         if (active && payload && payload.length && payload[0].payload) {
             const dataPoint: DataPoint = payload[0].payload;
-            const containerStyle: React.CSSProperties = {
-                margin: 0,
-                padding: 5,
-                backgroundColor: '#fff',
-                border: '1px solid #ccc',
-                whiteSpace: 'nowrap'
-            };
             return (
-                <div style={containerStyle}>
-                    <div style={{"fontWeight": "bold"}}>{dataPoint.name}</div>
+                <div className={classes.tooltip}>
+                    <div className={classes.tooltipTitle}>{dataPoint.name}</div>
                     <div>{dataPoint.evalText}</div>
                 </div>
             );
@@ -163,8 +172,8 @@ const EvalChart = (props: EvalChartProps) => {
                         <YAxis hide dataKey="yValue" domain={[-1, 1]} />
                         <defs>
                             <linearGradient id="splitColor" x1="0" y1="0" x2="0" y2="1">
-                                <stop offset={colouroffset} stopColor={colorScheme == 'light' ? '#e6e6e6' : '#ccc'} stopOpacity={1} />
-                                <stop offset={colouroffset} stopColor={colorScheme == 'light' ? '#333333' : '#000'} stopOpacity={1} />
+                                <stop offset={colouroffset} stopColor={isLightTheme ? '#e6e6e6' : '#ccc'} stopOpacity={1} />
+                                <stop offset={colouroffset} stopColor={isLightTheme ? '#333333' : '#000'} stopOpacity={1} />
                             </linearGradient>
                         </defs>
                         {currentPositionName &&

--- a/src/components/common/EvalChart.tsx
+++ b/src/components/common/EvalChart.tsx
@@ -1,0 +1,93 @@
+import { useContext } from "react";
+import { TreeStateContext } from "./TreeStateContext";
+import { ResponsiveContainer, AreaChart, Tooltip, Area, XAxis, YAxis } from "recharts";
+import { TreeNode } from "@/utils/treeReducer";
+import { ANNOTATION_INFO } from "@/utils/chess";
+import { formatScore } from "@/utils/score";
+import { Score } from "@/bindings";
+import { Stack, useMantineColorScheme } from "@mantine/core";
+
+const EvalChart = () => {
+    const { root, position } = useContext(TreeStateContext);
+    const { colorScheme } = useMantineColorScheme();
+
+    function* flatPath(node: TreeNode): Iterable<TreeNode> {
+        if (node.children.length > 0 && node.children[0].move) {
+            yield node.children[0];
+            yield* flatPath(node.children[0]);
+        }
+    }
+
+    function getYValue(score: Score | null): number | undefined {
+        if (score) {
+            let cp: number = score.value;
+            if (score.type == "mate") {
+                cp = score.value > 0 ? Infinity : -Infinity;
+            }
+            return 2 / (1 + Math.exp(-0.004 * cp)) - 1;
+        }
+    }
+
+    const data = [...flatPath(root)].map((node, i) => {
+        const move = node.move!;
+        const annotation = node.annotation ? ANNOTATION_INFO[node.annotation].name.toLowerCase() : undefined;
+        return {
+            name: `${Math.floor(i / 2) + 1}.${move.color === 'w' ? '' : '..'} ${move.san}${annotation ? ` (${annotation})` : ''}`,
+            evalText: node.score ? `Advantage: ${formatScore(node.score)}` : undefined,
+            yValue: getYValue(node.score)
+        }
+    });
+
+    const gradientOffset = () => {
+        const dataMax = Math.max(...data.map((i) => i.yValue ?? 0));
+        const dataMin = Math.min(...data.map((i) => i.yValue ?? 0));
+        
+        if (dataMax <= 0) return 0;
+        if (dataMin >= 0) return 1;
+        
+        return dataMax / (dataMax - dataMin);
+    };
+    
+    const offset = gradientOffset();
+
+    const CustomTooltip = ({ active, payload }: any) => {
+        if (active && payload && payload.length && payload[0].payload) {
+            const containerStyle: React.CSSProperties = {
+                margin: 0,
+                padding: 5,
+                backgroundColor: '#fff',
+                border: '1px solid #ccc',
+                whiteSpace: 'nowrap'
+            };
+            return (
+                <div style={containerStyle}>
+                    <div style={{"fontWeight": "bold"}}>{payload[0].payload.name}</div>
+                    <div>{payload[0].payload.evalText ?? "Not analysed"}</div>
+                </div>
+            );
+        }
+        console.log('none');
+        return null;
+    };
+    
+    return (
+        <Stack>
+            <ResponsiveContainer width="99%" height={220}>
+                <AreaChart data={data}>
+                    <Tooltip content={<CustomTooltip />} />
+                    <XAxis hide dataKey="name" />
+                    <YAxis hide dataKey="yValue" domain={[-1, 1]} />
+                    <defs>
+                        <linearGradient id="splitColor" x1="0" y1="0" x2="0" y2="1">
+                            <stop offset={offset} stopColor={colorScheme == 'light' ? '#e6e6e6' : '#ccc'} stopOpacity={1} />
+                            <stop offset={offset} stopColor={colorScheme == 'light' ? '#333333' : '#000'} stopOpacity={1} />
+                        </linearGradient>
+                    </defs>
+                    <Area type="linear" dataKey="yValue" stroke={'#ff9933'} fill="url(#splitColor)" />
+                </AreaChart>
+            </ResponsiveContainer>
+        </Stack>
+    )
+}
+
+export default EvalChart;

--- a/src/components/common/EvalChart.tsx
+++ b/src/components/common/EvalChart.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { TreeStateContext } from "./TreeStateContext";
+import { TreeDispatchContext, TreeStateContext } from "./TreeStateContext";
 import { ResponsiveContainer, AreaChart, Tooltip, Area, XAxis, YAxis } from "recharts";
 import { ListNode, TreeNode, treeIteratorMainLine } from "@/utils/treeReducer";
 import { ANNOTATION_INFO } from "@/utils/chess";
@@ -18,6 +18,7 @@ type DataPoint = {
 
 const EvalChart = () => {
     const { root, position } = useContext(TreeStateContext);
+    const dispatch = useContext(TreeDispatchContext);
     const { colorScheme } = useMantineColorScheme();
 
     function getYValue(score: Score | null): number | undefined {
@@ -96,11 +97,23 @@ const EvalChart = () => {
         }
         return null;
     };
+
+    const onChartClick = (data: any) => {
+        if (data && data.activePayload && data.activePayload.length && data.activePayload[0].payload) {
+            const dataPoint: DataPoint = data.activePayload[0].payload;
+            dispatch({
+                type: "GO_TO_MOVE",
+                payload: dataPoint.movePath,
+            });
+        }
+    }
+
+    const areaChartPropsHack = { cursor: "pointer" } as any;
     
     return (
         <Stack>
             <ResponsiveContainer width="99%" height={220}>
-                <AreaChart data={data}>
+                <AreaChart data={data} onClick={onChartClick} {...areaChartPropsHack}>
                     <Tooltip content={<CustomTooltip />} />
                     <XAxis hide dataKey="name" />
                     <YAxis hide dataKey="yValue" domain={[-1, 1]} />

--- a/src/components/common/EvalChart.tsx
+++ b/src/components/common/EvalChart.tsx
@@ -99,7 +99,7 @@ const EvalChart = (props: EvalChartProps) => {
                 (prevNode && !prevNode.score) ||
                 (nextNode && !nextNode.score);
             yield {
-                name: `${Math.floor(currentNode.node.halfMoves / 2) + 1}.${move.color === 'w' ? '' : '..'} ${move.san}${annotation ? ` (${annotation})` : ''}`,
+                name: `${Math.ceil(currentNode.node.halfMoves / 2)}.${move.color === 'w' ? '' : '..'} ${move.san}${annotation ? ` (${annotation})` : ''}`,
                 evalText: getEvalText(currentNode.node),
                 yValue: yValue,
                 altValue: needsAltValue ? 0 : undefined,

--- a/src/components/common/EvalChart.tsx
+++ b/src/components/common/EvalChart.tsx
@@ -1,12 +1,12 @@
 import { useContext } from "react";
 import { TreeDispatchContext, TreeStateContext } from "./TreeStateContext";
-import { ResponsiveContainer, AreaChart, Tooltip, Area, XAxis, YAxis } from "recharts";
-import { ListNode, TreeNode, treeIteratorMainLine } from "@/utils/treeReducer";
+import { ResponsiveContainer, AreaChart, Tooltip, Area, XAxis, YAxis, ReferenceLine } from "recharts";
+import { ListNode, treeIteratorMainLine } from "@/utils/treeReducer";
 import { ANNOTATION_INFO } from "@/utils/chess";
 import { formatScore } from "@/utils/score";
 import { Score } from "@/bindings";
 import { Stack, useMantineColorScheme } from "@mantine/core";
-import { skipWhile, takeWhile } from "@/utils/helperFunctions";
+import { arrayEquals, skipWhile, takeWhile } from "@/utils/helperFunctions";
 
 type DataPoint = {
     name: string;
@@ -64,9 +64,7 @@ const EvalChart = () => {
         }
     }
 
-    const data = [...getData()];
-
-    const gradientOffset = () => {
+    function gradientOffset(data: DataPoint[]) {
         const dataMax = Math.max(...data.map((i) => i.yValue ?? 0));
         const dataMin = Math.min(...data.map((i) => i.yValue ?? 0));
         
@@ -75,8 +73,6 @@ const EvalChart = () => {
         
         return dataMax / (dataMax - dataMin);
     };
-    
-    const offset = gradientOffset();
 
     const CustomTooltip = ({ active, payload }: any) => {
         if (active && payload && payload.length && payload[0].payload) {
@@ -108,6 +104,9 @@ const EvalChart = () => {
         }
     }
 
+    const data = [...getData()];
+    const currentPositionName = data.find(point => arrayEquals(point.movePath, position))?.name;
+    const colouroffset = gradientOffset(data);
     const areaChartPropsHack = { cursor: "pointer" } as any;
     
     return (
@@ -115,15 +114,18 @@ const EvalChart = () => {
             <ResponsiveContainer width="99%" height={220}>
                 <AreaChart data={data} onClick={onChartClick} {...areaChartPropsHack}>
                     <Tooltip content={<CustomTooltip />} />
-                    <XAxis hide dataKey="name" />
+                    <XAxis hide dataKey="name" type="category" />
                     <YAxis hide dataKey="yValue" domain={[-1, 1]} />
                     <defs>
                         <linearGradient id="splitColor" x1="0" y1="0" x2="0" y2="1">
-                            <stop offset={offset} stopColor={colorScheme == 'light' ? '#e6e6e6' : '#ccc'} stopOpacity={1} />
-                            <stop offset={offset} stopColor={colorScheme == 'light' ? '#333333' : '#000'} stopOpacity={1} />
+                            <stop offset={colouroffset} stopColor={colorScheme == 'light' ? '#e6e6e6' : '#ccc'} stopOpacity={1} />
+                            <stop offset={colouroffset} stopColor={colorScheme == 'light' ? '#333333' : '#000'} stopOpacity={1} />
                         </linearGradient>
                     </defs>
-                    <Area type="linear" dataKey="yValue" stroke={'#ff9933'} fill="url(#splitColor)" />
+                    {currentPositionName &&
+                        <ReferenceLine x={currentPositionName} stroke="#ff9933" />
+                    }
+                    <Area type="linear" dataKey="yValue" stroke="#ff9933" fill="url(#splitColor)" />
                     <Area type="linear" dataKey="altValue" stroke="#999999" strokeDasharray="3 3" activeDot={false} />
                 </AreaChart>
             </ResponsiveContainer>

--- a/src/components/panels/analysis/ReportModal.tsx
+++ b/src/components/panels/analysis/ReportModal.tsx
@@ -78,7 +78,7 @@ function ReportModal({
           type: "ADD_ANALYSIS",
           payload: analysisData,
         });
-      });
+      }).finally(() => setInProgress(false));
   }
 
   return (

--- a/src/layouts/BoardLayout.tsx
+++ b/src/layouts/BoardLayout.tsx
@@ -9,7 +9,7 @@ function BoardLayout({
 }) {
   return (
     <>
-      <Flex gap="md" wrap="wrap" align="start">
+      <Flex gap="md" wrap="nowrap" align="start">
         {board}
         <Stack
           sx={{

--- a/src/utils/helperFunctions.ts
+++ b/src/utils/helperFunctions.ts
@@ -17,3 +17,14 @@ export function* skipWhile<T>(collection: Iterable<T>, condition: (item: T) => b
         }
     }
 }
+
+export function arrayEquals<T>(a: T[], b: T[]): boolean {
+    if (a == b) return true;
+    if (a == undefined || b == undefined) return false;
+    if (a.length != b.length) return false;
+    
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] != b[i]) return false;
+    }
+    return true;
+}

--- a/src/utils/helperFunctions.ts
+++ b/src/utils/helperFunctions.ts
@@ -1,0 +1,19 @@
+
+export function* takeWhile<T>(collection: Iterable<T>, condition: (item: T) => boolean): Generator<T> {
+    for (let item of collection) {
+        if (condition(item)) yield item;
+        else break;
+    }
+}
+
+export function* skipWhile<T>(collection: Iterable<T>, condition: (item: T) => boolean): Generator<T> {
+    let conditionBroken = false;
+    for (let item of collection) {
+        if (!conditionBroken && !condition(item)) {
+            conditionBroken = true;
+        }
+        if (conditionBroken) {
+            yield item;
+        }
+    }
+}

--- a/src/utils/treeReducer.ts
+++ b/src/utils/treeReducer.ts
@@ -27,7 +27,7 @@ export interface TreeNode {
     commentText: string;
 }
 
-type ListNode = {
+export type ListNode = {
     position: number[];
     node: TreeNode;
 };
@@ -40,6 +40,14 @@ export function* treeIterator(node: TreeNode): Generator<ListNode> {
         for (let i = node.children.length - 1; i >= 0; i--) {
             stack.push({ position: [...position, i], node: node.children[i] });
         }
+    }
+}
+
+export function* treeIteratorMainLine(node: TreeNode): Generator<ListNode> {
+    let current: ListNode | undefined = { position: [], node };
+    while (current?.node) {
+        yield current;
+        current = { position: [...current.position, 0], node: current.node.children[0] };
     }
 }
 


### PR DESCRIPTION
Adds EvalChart component (issue https://github.com/franciscoBSalgueiro/en-croissant/issues/57):

![image](https://github.com/franciscoBSalgueiro/en-croissant/assets/25903992/053873fc-c227-4080-9117-e6f5d1f5e87d)

I think all the functionality it needs is there, there are some UI issues but I didn't want to go crazy changing a bunch of things for it if it could be unnecessary:
- Not sure about where in the UI it should go, for now I just added it to the Analysis page below Game Notation. Maybe GameNotation could be a split card with multiple modes, with some sort of switch on it to change between them e.g.
    1. Notation only
    2. Split notation / chart (left/right, or top/bottom if expanded)
    3. Chart only
- Issue with the chart and its container growing excessively, it looks alright most of the time but if you start resizing the window it can grow to full width and put the entire side tab below the board. Maybe this needs some change to `BoardLayout` so that the layout is fixed 2 columns instead of allowing it to wrap - **I added `nowrap` to `BoardLayout` for this**