### PR TITLE
[WIP] Align calculation of total games with the number of downloaded games. Closes #84

### DIFF
--- a/src/components/common/AccountCards.tsx
+++ b/src/components/common/AccountCards.tsx
@@ -24,7 +24,8 @@ function AccountCards({
             (account.perfs.bullet?.games ?? 0) +
             (account.perfs.blitz?.games ?? 0) +
             (account.perfs.rapid?.games ?? 0) +
-            (account.perfs.classical?.games ?? 0);
+            (account.perfs.classical?.games ?? 0) +
+            (account.perfs.correspondence?.games ?? 0) +;
 
           const stats = [];
           const speeds = ["bullet", "blitz", "rapid", "classical"] as const;


### PR DESCRIPTION
Prevent the account cards from showing a percentage of downloaded games greater than 100% by aligning the calculation of games to the way games are downloaded.

![grafik](https://github.com/franciscoBSalgueiro/en-croissant/assets/15523614/5cd76be0-b398-4b27-b00d-dffc75d72861)

I need to identify other causes of games missing in the total, before this PR is ready.
