### PR TITLE
Add option to save engine settings as default

### DIFF
--- a/src/atoms/atoms.ts
+++ b/src/atoms/atoms.ts
@@ -247,17 +247,23 @@ export type EngineSettings = {
 };
 
 export const tabEngineSettingsFamily = atomFamily(
-    ({ tab, engine }: { tab: string; engine: string }) =>
-        atom<EngineSettings>({
-            enabled: false,
-            go: {
-                t: "Depth",
-                c: 24,
-            },
-            cores: 2,
-            numberLines: 3,
-            extraOptions: [],
-        }),
+    ({ tab, engine }: { tab: string; engine: string }) => {
+        const savedDefault = localStorage.getItem(`engine-${engine}`);
+        return atom<EngineSettings>(
+            savedDefault !== null
+                ? { ...JSON.parse(savedDefault), enabled: false } as EngineSettings
+                :
+                {
+                    enabled: false,
+                    go: {
+                        t: "Depth",
+                        c: 24,
+                    },
+                    cores: 2,
+                    numberLines: 3,
+                    extraOptions: [],
+                })
+    },
     (a, b) => a.tab === b.tab && a.engine === b.engine
 );
 

--- a/src/components/panels/analysis/BestMoves.tsx
+++ b/src/components/panels/analysis/BestMoves.tsx
@@ -245,6 +245,7 @@ export default function BestMovesComponent({
           </ActionIcon>
         </Box>
         <EngineSettings
+          engine={engine.name}
           settingsOn={settingsOn}
           settings={settings}
           setSettings={setSettings}

--- a/src/components/panels/analysis/EngineSettings.tsx
+++ b/src/components/panels/analysis/EngineSettings.tsx
@@ -20,12 +20,14 @@ import LinesSlider from "./LinesSlider";
 import { IconPlus, IconX } from "@tabler/icons-react";
 
 interface EngineSettingsProps {
+  engine: string;
   settingsOn: boolean;
   settings: EngineSettings;
   setSettings: React.Dispatch<React.SetStateAction<EngineSettings>>;
 }
 
 function EngineSettings({
+  engine,
   settingsOn,
   settings,
   setSettings,
@@ -93,14 +95,25 @@ function EngineSettings({
           />
         </SimpleGrid>
 
-        <Button
-          variant="light"
-          size="xs"
-          mt="sm"
-          onClick={() => setAdvancedOptions(true)}
-        >
-          Advanced Options
-        </Button>
+        <Group>
+          <Button
+            variant="default"
+            size="xs"
+            mt="sm"
+            onClick={() => setAdvancedOptions(true)}
+          >
+            Advanced options
+          </Button>
+
+          <Button
+            size="xs"
+            mt="sm"
+            onClick={() => localStorage.setItem(`engine-${engine}`, JSON.stringify(settings))}
+          >
+            Save as default
+          </Button>
+        </Group>
+
       </Collapse>
     </>
   );


### PR DESCRIPTION
This adds a new button that saves the current engine settings and applies it to all new instances of that engine on new tabs (including after app restart).