### PR TITLE
fix: include top level comments in PGN Input

### DIFF
--- a/src/utils/chess.ts
+++ b/src/utils/chess.ts
@@ -128,24 +128,24 @@ export function getMoveText(
         isFirst?: boolean;
     }
 ): string {
-    if (tree.move === null) {
-        return "";
-    }
     const isBlack = tree.halfMoves % 2 === 0;
     const moveNumber = Math.ceil(tree.halfMoves / 2);
     let moveText = "";
-    if (isBlack) {
-        if (opt.isFirst) {
-            moveText += `${moveNumber}... `;
+
+    if (tree.move) {
+        if (isBlack) {
+            if (opt.isFirst) {
+                moveText += `${moveNumber}... `;
+            }
+        } else {
+            moveText += `${moveNumber}. `;
         }
-    } else {
-        moveText += `${moveNumber}. `;
+        moveText += tree.move.san;
+        if (opt.symbols) {
+            moveText += tree.annotation;
+        }
+        moveText += " ";
     }
-    moveText += tree.move.san;
-    if (opt.symbols) {
-        moveText += tree.annotation;
-    }
-    moveText += " ";
 
     if (opt.comments || opt.specialSymbols) {
         let content = "{";
@@ -224,6 +224,9 @@ export function getPGN(
         pgn += '[FEN "' + tree.fen + '"]\n';
     }
     pgn += "\n";
+    if (root && tree.commentText !== null) {
+        pgn += `${getMoveText(tree, {symbols, comments, specialSymbols})}`
+    }
     const variationsPGN = variations
         ? tree.children.slice(1).map(
             (variation) =>


### PR DESCRIPTION
This PR fixes an issue with top level comments being ignored when loading a PGN.

## Issue description
Version: 0.6.0

Importing the below 
```
[Event "test"]
[Site "test"]
{ Top level comment }
1. e4 f5 2. d4 g5 3. Qh5# { 1-0 White wins by checkmate. } *
```
results in
![image](https://github.com/franciscoBSalgueiro/en-croissant/assets/4732211/43e42140-b92e-4abf-81a3-79f237194ed9)