### PR TITLE
feature: colours in csl/cal markup

### DIFF
--- a/src/utils/chess.ts
+++ b/src/utils/chess.ts
@@ -97,9 +97,10 @@ type AnnotationInfo = {
 
 export const BRUSH_COLORS = new Map<string, string>([
     ["DEFAULT", "green"],
+    ["R", "red"],
     ["G", "green"],
-    ["B", "blue"],
-    ["R", "red"]]);
+    ["Y", "yellow"],
+    ["B", "blue"]]);
 
 export const ANNOTATION_INFO: Record<Annotation, AnnotationInfo> = {
     "": { name: "None", color: "gray" },
@@ -435,13 +436,13 @@ function innerParsePGN(
                 root.score = parseScore(evl[1]);
             }
 
-            const csl = comment.match(/\[%csl\s+((?:[RGB][a-h][1-8],?)+)\]/);
+            const csl = comment.match(/\[%csl\s+((?:[RGYB][a-h][1-8],?)+)\]/);
             if (csl) {
                 root.shapes.push(...parseCsl(csl[1]));
             }
 
             const cal = comment.match(
-                /\[%cal\s+((?:[RGB][a-h][1-8][a-h][1-8],?)+)\]/
+                /\[%cal\s+((?:[RGYB][a-h][1-8][a-h][1-8],?)+)\]/
             );
             if (cal) {
                 root.shapes.push(...parseCal(cal[1]));

--- a/src/utils/chess.ts
+++ b/src/utils/chess.ts
@@ -42,12 +42,12 @@ function parseCsl(csl: string): DrawShape[] {
         if (square.length === 2) {
             return {
                 orig: square as Square,
-                brush: "green",
+                brush: BRUSH_COLORS.get("DEFAULT"),
             } as DrawShape;
         } else if (square.length === 3) {
             return {
                 orig: square.slice(1) as Square,
-                brush: "green",
+                brush: BRUSH_COLORS.get(square[0].toUpperCase()),
             } as DrawShape;
         } else {
             throw new Error("Invalid square: " + square);
@@ -57,19 +57,19 @@ function parseCsl(csl: string): DrawShape[] {
     return shapes;
 }
 
-function parseCal(csl: string): DrawShape[] {
-    const shapes = csl.split(",").map((square) => {
+function parseCal(cal: string): DrawShape[] {
+    const shapes = cal.split(",").map((square) => {
         if (square.length === 4) {
             return {
                 orig: square.slice(0, 2) as Square,
                 dest: square.slice(2) as Square,
-                brush: "green",
+                brush: BRUSH_COLORS.get("DEFAULT"),
             } as DrawShape;
         } else if (square.length === 5) {
             return {
                 orig: square.slice(1, 3) as Square,
                 dest: square.slice(3) as Square,
-                brush: "green",
+                brush: BRUSH_COLORS.get(square[0].toUpperCase()),
             } as DrawShape;
         } else {
             throw new Error("Invalid square: " + square);
@@ -94,6 +94,12 @@ type AnnotationInfo = {
     name: string;
     color: MantineColor;
 };
+
+export const BRUSH_COLORS = new Map<string, string>([
+    ["DEFAULT", "green"],
+    ["G", "green"],
+    ["B", "blue"],
+    ["R", "red"]]);
 
 export const ANNOTATION_INFO: Record<Annotation, AnnotationInfo> = {
     "": { name: "None", color: "gray" },
@@ -156,20 +162,17 @@ export function getMoveText(
 
         if (opt.specialSymbols && tree.shapes.length > 0) {
             const squares = tree.shapes
-                .filter((shape) => shape.dest === undefined)
-                .map((shape) => {
-                    return shape.orig;
-                });
+                .filter((shape) => shape.dest === undefined);
             const arrows = tree.shapes
-                .filter((shape) => shape.dest !== undefined)
-                .map((shape) => {
-                    return shape.orig + shape.dest;
-                });
+                .filter((shape) => shape.dest !== undefined);
+
             if (squares.length > 0) {
-                content += `[%csl ${squares.join(",")}] `;
+                content += "[%csl " + squares.map(
+                    (shape) => {return shape.brush[0].toUpperCase() + shape.orig}).join(",") + "]";
             }
             if (arrows.length > 0) {
-                content += `[%cal ${arrows.join(",")}] `;
+                content += "[%cal " + arrows.map(
+                    (shape) => {return shape.brush[0].toUpperCase() + shape.orig + shape.dest}).join(",") + "]";
             }
         }
 
@@ -432,13 +435,13 @@ function innerParsePGN(
                 root.score = parseScore(evl[1]);
             }
 
-            const csl = comment.match(/\[%csl\s+((?:[a-h][1-8],?)+)\]/);
+            const csl = comment.match(/\[%csl\s+((?:[RGB][a-h][1-8],?)+)\]/);
             if (csl) {
                 root.shapes.push(...parseCsl(csl[1]));
             }
 
             const cal = comment.match(
-                /\[%cal\s+((?:[a-h][1-8][a-h][1-8],?)+)\]/
+                /\[%cal\s+((?:[RGB][a-h][1-8][a-h][1-8],?)+)\]/
             );
             if (cal) {
                 root.shapes.push(...parseCal(cal[1]));


### PR DESCRIPTION
This PR adds support for storing/reading coloured markup (i.e. `[%csl Re2,Gf2,Bg2][%cal Re2e4,Gf2f4,Bg2g4]`).

```
[Event "test"]
{[%csl Re2,Gf2,Bg2][%cal Re2e4,Gf2f4,Bg2g4] RGB test } 1. e4 f5 2. d4 g5 3. Qh5# 1-0
```

![image](https://github.com/franciscoBSalgueiro/en-croissant/assets/4732211/93096cf9-a6f9-41b0-975a-ee7dde684e38)
