### PR TITLE
fix: recognizing start/end of game when reading from a PGN

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1093,6 +1093,7 @@ dependencies = [
  "quick-xml 0.30.0",
  "rand 0.8.5",
  "rayon",
+ "regex",
  "reqwest",
  "rusqlite",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,6 +53,7 @@ oauth2 = "4.4.2"
 axum = "0.6.20"
 tar = "0.4.40"
 sysinfo = "0.29.10"
+regex = "1.8.4"
 
 [features]
 # by default Tauri runs in production mode


### PR DESCRIPTION
## Issue
The current version does not properly recognize a situation where a line begins with `[` character, while also *not being* a header. See below example:
```
[Event "test"]

1. e4 f5 2. d4 g5 { This comment will break pgn parsing
[%cal Ge7b7]} 3. Qh5# 1-0
```
Importing this will fail.

## Solution
This PR improves the way games are recognized within a PGN file. Following https://ia802908.us.archive.org/26/items/pgn-standard-1994-03-12/PGN_standard_1994-03-12.txt, section `8.2.6 Game Termination Markers` GTMs are used to determine whether we've reached an end of a game. Additionally, the current way of counting games has been slightly amended (look for `[Event` as a sign of a new game, as according to the above spec it's the first one in the Seven Tag Roster, section `8.1.1`)