### PR TITLE
Prevent divide by zero in harmonic mean

### DIFF
--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -73,6 +73,6 @@ export function mean(arr: number[]): number {
 }
 
 export function harmonicMean(arr: number[]): number {
-    const sum = arr.reduce((a, b) => a + 1 / b, 0);
+    const sum = arr.reduce((a, b) => a + 1 / Math.max(1, b), 0);
     return arr.length / sum;
 }


### PR DESCRIPTION
Fixes issue https://github.com/franciscoBSalgueiro/en-croissant/issues/105

The problem was some moves having accuracy of 0, so harmonic mean could not be calculated and `stats.whiteAccuracy` evaluates to false

I'm not sure if this change is necessarily the correct way to calculate harmonic mean but it is the same as what lichess does:
https://github.com/lichess-org/lila/blob/master/modules/common/src/main/Maths.scala#L23

Also of note: for their accuracy they calculate both harmonic mean and a weighted mean and average the two
https://github.com/lichess-org/lila/blob/master/modules/analyse/src/main/AccuracyPercent.scala
(I don't have an opinion one way or the other just noticed there ended up being a significant difference in accuracy calculated for the PGN mentioned in above issue on lichess vs here - Lichess [37%/35%] en-croissant [11.9%/12.6%])