### PR TITLE
Added ability to take back moves when playing against engine

### DIFF
--- a/src/components/boards/Board.tsx
+++ b/src/components/boards/Board.tsx
@@ -126,7 +126,7 @@ function Board({
   boardRef,
   saveFile,
   addGame,
-  canTakeBack: cantakeBack,
+  canTakeBack,
   root,
   position,
   whiteTime,
@@ -299,9 +299,13 @@ function Board({
   const controls = useMemo(
     () => (
       <ActionIcon.Group>
-        {cantakeBack && (
+        {canTakeBack && (
           <Tooltip label="Take Back">
-            <ActionIcon variant="default" size="lg" onClick={() => dispatch({type: "DELETE_MOVE"})}>
+            <ActionIcon
+              variant="default"
+              size="lg"
+              onClick={() => dispatch({ type: "DELETE_MOVE" })}
+            >
               <IconArrowBack />
             </ActionIcon>
           </Tooltip>

--- a/src/components/boards/Board.tsx
+++ b/src/components/boards/Board.tsx
@@ -53,6 +53,7 @@ import {
 import { mergeRefs, useElementSize } from "@mantine/hooks";
 import { notifications } from "@mantine/notifications";
 import {
+  IconArrowBack,
   IconChevronRight,
   IconDeviceFloppy,
   IconEdit,
@@ -104,6 +105,7 @@ interface ChessboardProps {
   boardRef: React.MutableRefObject<HTMLDivElement | null>;
   saveFile?: () => void;
   addGame?: () => void;
+  canTakeBack?: boolean;
   whiteTime?: number;
   blackTime?: number;
   whiteTc?: TimeControlField;
@@ -124,6 +126,7 @@ function Board({
   boardRef,
   saveFile,
   addGame,
+  canTakeBack: cantakeBack,
   root,
   position,
   whiteTime,
@@ -296,6 +299,13 @@ function Board({
   const controls = useMemo(
     () => (
       <ActionIcon.Group>
+        {cantakeBack && (
+          <Tooltip label="Take Back">
+            <ActionIcon variant="default" size="lg" onClick={() => dispatch({type: "DELETE_MOVE"})}>
+              <IconArrowBack />
+            </ActionIcon>
+          </Tooltip>
+        )}
         <Tooltip
           label={
             currentTab?.type === "analysis" ? "Play from here" : "Analyze game"

--- a/src/components/boards/BoardGame.tsx
+++ b/src/components/boards/BoardGame.tsx
@@ -514,7 +514,9 @@ function BoardGame() {
     }
   }, [gameState, intervalId, pos?.turn]);
 
-  const onePlayerIsEngine = (players.white.type === "engine" || players.black.type === "engine") && players.white.type !== players.black.type;
+  const onePlayerIsEngine =
+    (players.white.type === "engine" || players.black.type === "engine") &&
+    players.white.type !== players.black.type;
 
   return (
     <>

--- a/src/components/boards/BoardGame.tsx
+++ b/src/components/boards/BoardGame.tsx
@@ -514,6 +514,8 @@ function BoardGame() {
     }
   }, [gameState, intervalId, pos?.turn]);
 
+  const onePlayerIsEngine = (players.white.type === "engine" || players.black.type === "engine") && players.white.type !== players.black.type;
+
   return (
     <>
       <Portal target="#left" style={{ height: "100%" }}>
@@ -527,6 +529,7 @@ function BoardGame() {
           viewOnly={gameState !== "playing"}
           disableVariations
           boardRef={boardRef}
+          canTakeBack={onePlayerIsEngine}
           movable={movable}
           root={root}
           position={position}


### PR DESCRIPTION
Implemented the idea provided by #194 by adding a button on the controls specifically when a player is paired against an engine.
![Screenshot of the new control](https://github.com/franciscoBSalgueiro/en-croissant/assets/75273490/73f529b7-e3a6-441f-aeba-5915a5cc7f93)
