### PR TITLE
A few improvements on the Files page

### DIFF
--- a/src/components/files/FilesPage.tsx
+++ b/src/components/files/FilesPage.tsx
@@ -67,7 +67,8 @@ const useFileDirectory = (dir: string) => {
     "file-directory",
     async () => {
       const files = await readDir(dir, { recursive: true });
-      const filesInfo = await processFiles(files as MetadataOrEntry[]);
+      const filesInfo = await processFiles(
+        files.filter(f => !f.name?.startsWith(".")) as MetadataOrEntry[]);
 
       return filesInfo;
     },

--- a/src/components/files/FilesPage.tsx
+++ b/src/components/files/FilesPage.tsx
@@ -84,9 +84,8 @@ const useFileDirectory = (dir: string) => {
             return 0;
           } else if (a.children == null && b.children == null) {
             return 0;
-          } else {
-            return -1;
           }
+          return -1;
         });
     },
   );

--- a/src/components/files/FilesPage.tsx
+++ b/src/components/files/FilesPage.tsx
@@ -80,9 +80,11 @@ const useFileDirectory = (dir: string) => {
         .sort((a, b) => {
           if (a.children != null && b.children == null) {
             return 1;
-          } else if (a.children != null && b.children != null) {
+          }
+          if (a.children != null && b.children != null) {
             return 0;
-          } else if (a.children == null && b.children == null) {
+          }
+          if (a.children == null && b.children == null) {
             return 0;
           }
           return -1;

--- a/src/components/files/FilesPage.tsx
+++ b/src/components/files/FilesPage.tsx
@@ -70,7 +70,24 @@ const useFileDirectory = (dir: string) => {
       const filesInfo = await processFiles(
         files.filter(f => !f.name?.startsWith(".")) as MetadataOrEntry[]);
 
-      return filesInfo;
+      return filesInfo
+        .sort((a, b) => {
+          return b.name.localeCompare(a.name, "en", {sensitivity: "base"})
+        })
+        .filter((f) => {
+          return (f.children === undefined || (f.children?.length > 0))
+        })
+        .sort((a, b) => {
+          if (a.children != null && b.children == null) {
+            return 1;
+          } else if (a.children != null && b.children != null) {
+            return 0;
+          } else if (a.children == null && b.children == null) {
+            return 0;
+          } else {
+            return -1;
+          }
+        });
     },
   );
   return {

--- a/src/components/files/FilesPage.tsx
+++ b/src/components/files/FilesPage.tsx
@@ -68,14 +68,15 @@ const useFileDirectory = (dir: string) => {
     async () => {
       const files = await readDir(dir, { recursive: true });
       const filesInfo = await processFiles(
-        files.filter(f => !f.name?.startsWith(".")) as MetadataOrEntry[]);
+        files.filter((f) => !f.name?.startsWith(".")) as MetadataOrEntry[],
+      );
 
       return filesInfo
         .sort((a, b) => {
-          return b.name.localeCompare(a.name, "en", {sensitivity: "base"})
+          return b.name.localeCompare(a.name, "en", { sensitivity: "base" });
         })
         .filter((f) => {
-          return (f.children === undefined || (f.children?.length > 0))
+          return f.children === undefined || f.children?.length > 0;
         })
         .sort((a, b) => {
           if (a.children != null && b.children == null) {

--- a/src/components/files/file.ts
+++ b/src/components/files/file.ts
@@ -71,7 +71,7 @@ export async function readFileMetadata(
   const numGames = await count_pgn_games(path);
   return {
     path,
-    name: name.replace(".pgn", ""),
+    name: name,
     numGames,
     metadata,
     lastModified: fileMetadata.last_modified,

--- a/src/components/files/file.ts
+++ b/src/components/files/file.ts
@@ -71,7 +71,7 @@ export async function readFileMetadata(
   const numGames = await count_pgn_games(path);
   return {
     path,
-    name: name,
+    name: name.replace(".pgn", ""),
     numGames,
     metadata,
     lastModified: fileMetadata.last_modified,


### PR DESCRIPTION
Don't process hidden files (starting with a `.`). If you keep pgns in version control hidden files clutter the UI.

Pre-sort the results alphabetically by name, with folders on top. Ignore "empty" folders (without pgns inside). Also, no need to hide the `.pgn` extension.