### PR TITLE
Visible scrollbars in settings

### DIFF
--- a/src/components/settings/BoardSelect.tsx
+++ b/src/components/settings/BoardSelect.tsx
@@ -107,7 +107,7 @@ export default function BoardSelect() {
 
       <Combobox.Dropdown>
         <Combobox.Options>
-          <ScrollArea.Autosize mah={200} type="scroll">
+          <ScrollArea.Autosize mah={200} type="always">
             {options}
           </ScrollArea.Autosize>
         </Combobox.Options>

--- a/src/components/settings/PiecesSelect.tsx
+++ b/src/components/settings/PiecesSelect.tsx
@@ -108,7 +108,7 @@ export default function PiecesSelect() {
 
       <Combobox.Dropdown>
         <Combobox.Options>
-          <ScrollArea.Autosize mah={200} type="scroll">
+          <ScrollArea.Autosize mah={200} type="always">
             {options}
           </ScrollArea.Autosize>
         </Combobox.Options>

--- a/src/components/settings/SoundSelect.tsx
+++ b/src/components/settings/SoundSelect.tsx
@@ -81,7 +81,7 @@ export default function SoundSelect() {
 
       <Combobox.Dropdown>
         <Combobox.Options>
-          <ScrollArea.Autosize mah={200} type="scroll">
+          <ScrollArea.Autosize mah={200} type="always">
             {options}
           </ScrollArea.Autosize>
         </Combobox.Options>


### PR DESCRIPTION
I've had some difficulty with visual indications of scrollbars in some of the setting pages, so I wanted to make it more clear. The scrollbars in the affected scrollareas will now always be visible when the dropdown is visible.

![image](https://github.com/franciscoBSalgueiro/en-croissant/assets/99344963/d86114aa-e2dd-4c85-b458-872814336650)
