### PR TITLE
Added move notation types

### DIFF
--- a/src/components/boards/MoveCell.tsx
+++ b/src/components/boards/MoveCell.tsx
@@ -1,19 +1,14 @@
 import { moveNotationTypeAtom } from "@/state/atoms";
-import { ANNOTATION_INFO, type Annotation } from "@/utils/annotation";
+import {
+  ANNOTATION_INFO,
+  type Annotation,
+  addPieceSymbol,
+} from "@/utils/annotation";
 import { Box, rgba, useMantineTheme } from "@mantine/core";
 import { IconFlag } from "@tabler/icons-react";
 import { useAtom } from "jotai";
 import { type ForwardedRef, forwardRef } from "react";
 import * as classes from "./MoveCell.css";
-
-const pieceChars = { K: "♔", Q: "♕", R: "♖", B: "♗", N: "♘" };
-
-function addPieceIcon(move: string): string {
-  const pieceChar = pieceChars[move[0] as keyof typeof pieceChars];
-
-  if (typeof pieceChar === "undefined") return move;
-  return pieceChar + move.slice(1);
-}
 
 interface MoveCellProps {
   annotations: Annotation[];
@@ -71,7 +66,7 @@ const MoveCell = forwardRef(function MoveCell(
       onContextMenu={props.onContextMenu}
     >
       {props.isStart && <IconFlag style={{ marginRight: 5 }} size="0.875rem" />}
-      {moveNotationType === "symbols" ? addPieceIcon(props.move) : props.move}
+      {moveNotationType === "symbols" ? addPieceSymbol(props.move) : props.move}
       {props.annotations.join("")}
     </Box>
   );

--- a/src/components/boards/MoveCell.tsx
+++ b/src/components/boards/MoveCell.tsx
@@ -1,8 +1,19 @@
+import { moveNotationTypeAtom } from "@/state/atoms";
 import { ANNOTATION_INFO, type Annotation } from "@/utils/annotation";
 import { Box, rgba, useMantineTheme } from "@mantine/core";
 import { IconFlag } from "@tabler/icons-react";
+import { useAtom } from "jotai";
 import { type ForwardedRef, forwardRef } from "react";
 import * as classes from "./MoveCell.css";
+
+const pieceChars = { K: "♔", Q: "♕", R: "♖", B: "♗", N: "♘" };
+
+function addPieceIcon(move: string): string {
+  const pieceChar = pieceChars[move[0] as keyof typeof pieceChars];
+
+  if (typeof pieceChar === "undefined") return move;
+  return pieceChar + move.slice(1);
+}
 
 interface MoveCellProps {
   annotations: Annotation[];
@@ -17,6 +28,8 @@ const MoveCell = forwardRef(function MoveCell(
   props: MoveCellProps,
   ref: ForwardedRef<HTMLButtonElement>,
 ) {
+  const [moveNotationType] = useAtom(moveNotationTypeAtom);
+
   const color = ANNOTATION_INFO[props.annotations[0]]?.color || "gray";
   const theme = useMantineTheme();
   const hoverOpacity = props.isCurrentVariation ? 0.25 : 0.1;
@@ -58,7 +71,8 @@ const MoveCell = forwardRef(function MoveCell(
       onContextMenu={props.onContextMenu}
     >
       {props.isStart && <IconFlag style={{ marginRight: 5 }} size="0.875rem" />}
-      {props.move + props.annotations.join("")}
+      {moveNotationType === "symbols" ? addPieceIcon(props.move) : props.move}
+      {props.annotations.join("")}
     </Box>
   );
 });

--- a/src/components/panels/database/OpeningsTable.tsx
+++ b/src/components/panels/database/OpeningsTable.tsx
@@ -1,7 +1,10 @@
 import { TreeStateContext } from "@/components/common/TreeStateContext";
+import { moveNotationTypeAtom } from "@/state/atoms";
+import { addPieceSymbol } from "@/utils/annotation";
 import type { Opening } from "@/utils/db";
 import { formatNumber } from "@/utils/format";
 import { Group, Progress, Text } from "@mantine/core";
+import { useAtom } from "jotai";
 import { DataTable } from "mantine-datatable";
 import { memo, useContext } from "react";
 import { useStore } from "zustand";
@@ -15,6 +18,7 @@ function OpeningsTable({
 }) {
   const store = useContext(TreeStateContext)!;
   const makeMove = useStore(store, (s) => s.makeMove);
+  const [moveNotationType] = useAtom(moveNotationTypeAtom);
 
   const whiteTotal = openings?.reduce((acc, curr) => acc + curr.white, 0);
   const blackTotal = openings?.reduce((acc, curr) => acc + curr.black, 0);
@@ -60,7 +64,11 @@ function OpeningsTable({
                   Game end
                 </Text>
               );
-            return <Text fz="sm">{move}</Text>;
+            return (
+              <Text fz="sm">
+                {moveNotationType === "symbols" ? addPieceSymbol(move) : move}
+              </Text>
+            );
           },
         },
         {

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -7,6 +7,7 @@ import {
   minimumGamesAtom,
   moveInputAtom,
   moveMethodAtom,
+  moveNotationTypeAtom,
   nativeBarAtom,
   percentageCoverageAtom,
   previewBoardOnHoverAtom,
@@ -71,6 +72,7 @@ export default function Page() {
   filesDirectory = filesDirectory || documentDir;
 
   const [moveMethod, setMoveMethod] = useAtom(moveMethodAtom);
+  const [moveNotationType, setMoveNotationType] = useAtom(moveNotationTypeAtom);
 
   return (
     <Tabs defaultValue="board" orientation="vertical" h="100%">
@@ -138,7 +140,30 @@ export default function Page() {
                 </div>
                 <SettingsSwitch atom={showArrowsAtom} />
               </Group>
-
+              <Group
+                justify="space-between"
+                wrap="nowrap"
+                gap="xl"
+                className={classes.item}
+              >
+                <div>
+                  <Text>Move notation</Text>
+                  <Text size="xs" c="dimmed">
+                    Choose how to display pieces in notation
+                  </Text>
+                </div>
+                <Select
+                  data={[
+                    { label: "Letters (K Q R B N)", value: "letters" },
+                    { label: "Symbols (♔♕♖♗♘)", value: "symbols" },
+                  ]}
+                  allowDeselect={false}
+                  value={moveNotationType}
+                  onChange={(val) =>
+                    setMoveNotationType(val as "letters" | "symbols")
+                  }
+                />
+              </Group>
               <Group
                 justify="space-between"
                 wrap="nowrap"

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -113,6 +113,10 @@ export const fontSizeAtom = atomWithStorage(
   Number.parseInt(document.documentElement.style.fontSize) || 100,
 );
 
+export const moveNotationTypeAtom = atomWithStorage<"letters" | "symbols">(
+  "letters",
+  "symbols",
+);
 export const moveMethodAtom = atomWithStorage<"drag" | "select" | "both">(
   "move-method",
   "drag",

--- a/src/utils/annotation.ts
+++ b/src/utils/annotation.ts
@@ -1,5 +1,14 @@
 import type { MantineColor } from "@mantine/core";
 
+const pieceChars = { K: "♔", Q: "♕", R: "♖", B: "♗", N: "♘" };
+
+export function addPieceSymbol(move: string): string {
+  const pieceChar = pieceChars[move[0] as keyof typeof pieceChars];
+
+  if (typeof pieceChar === "undefined") return move;
+  return pieceChar + move.slice(1);
+}
+
 export type Annotation =
   | ""
   | "!"


### PR DESCRIPTION
This feature adds a settings to choose if pieces in notation are written with letters (K Q R B N) or with symbols (♔♕♖♗♘). This setting is visible in the moves list next to the board, as well as the opening database table.

Example with pieces:

![image](https://github.com/franciscoBSalgueiro/en-croissant/assets/32744805/4bc6da2e-3812-43b1-988c-faa5a60c8fd3)

Example with symbols:

![image](https://github.com/franciscoBSalgueiro/en-croissant/assets/32744805/8f9b2693-d7e6-492c-80bb-31eadeb42707)

Feature requested by #291 