### PR TITLE
Truncate Score Display

### DIFF
--- a/src/components/boards/EvalBar.tsx
+++ b/src/components/boards/EvalBar.tsx
@@ -39,7 +39,7 @@ function EvalBar({
           py={3}
           mt={orientation === "black" ? "auto" : undefined}
         >
-          {score.value <= 0 && formatScore(score, 1).replace(/\+|-/, "")}
+          {score.value <= 0 && formatScore(score).replace(/\+|-/, "")}
         </Text>
       </Box>,
       <Box
@@ -59,7 +59,7 @@ function EvalBar({
           ta="center"
           mt={orientation === "white" ? "auto" : undefined}
         >
-          {score.value > 0 && formatScore(score, 1).slice(1)}
+          {score.value > 0 && formatScore(score).slice(1)}
         </Text>
       </Box>,
     ];

--- a/src/components/boards/EvalBar.tsx
+++ b/src/components/boards/EvalBar.tsx
@@ -58,6 +58,11 @@ function EvalBar({
           c={theme.colors.dark[8]}
           ta="center"
           mt={orientation === "white" ? "auto" : undefined}
+          style={{
+            textOverflow: "ellipsis",
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+          }}
         >
           {score.value > 0 && formatScore(score).slice(1)}
         </Text>

--- a/src/components/panels/analysis/BestMoves.tsx
+++ b/src/components/panels/analysis/BestMoves.tsx
@@ -370,7 +370,7 @@ function EngineTop({
                 Eval
               </Text>
               <Text fw="bold" fz="md">
-                {formatScore(engineVariations[0].score.value, 1) ?? 0}
+                {formatScore(engineVariations[0].score.value) ?? 0}
               </Text>
             </Stack>
             <Stack align="center" gap={0}>

--- a/src/components/panels/analysis/ScoreBubble.tsx
+++ b/src/components/panels/analysis/ScoreBubble.tsx
@@ -1,6 +1,6 @@
 import type { Score } from "@/bindings";
 import { formatScore } from "@/utils/score";
-import { Box, Progress, Text } from "@mantine/core";
+import { Box, Progress, Text, Tooltip } from "@mantine/core";
 import * as classes from "./ScoreBubble.css";
 
 function ScoreBubble({
@@ -71,20 +71,26 @@ function ScoreBubble({
         boxShadow: theme.shadows.md,
       })}
     >
-      <Text
-        fw={700}
-        c={score.value.value >= 0 ? "black" : "white"}
-        size={size}
-        ta="center"
-        style={(theme) => ({
-          fontFamily: theme.fontFamilyMonospace,
-          textOverflow: "ellipsis",
-          overflow: "hidden",
-          whiteSpace: "nowrap",
-        })}
+      <Tooltip
+        position="left"
+        color={score.value.value < 0 ? "dark" : undefined}
+        label={formatScore(score.value)}
       >
-        {formatScore(score.value)}
-      </Text>
+        <Text
+          fw={700}
+          c={score.value.value >= 0 ? "black" : "white"}
+          size={size}
+          ta="center"
+          style={(theme) => ({
+            fontFamily: theme.fontFamilyMonospace,
+            textOverflow: "ellipsis",
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+          })}
+        >
+          {formatScore(score.value)}
+        </Text>
+      </Tooltip>
     </Box>
   );
 }

--- a/src/components/panels/analysis/ScoreBubble.tsx
+++ b/src/components/panels/analysis/ScoreBubble.tsx
@@ -78,6 +78,9 @@ function ScoreBubble({
         ta="center"
         style={(theme) => ({
           fontFamily: theme.fontFamilyMonospace,
+          textOverflow: "ellipsis",
+          overflow: "hidden",
+          whiteSpace: "nowrap",
         })}
       >
         {formatScore(score.value)}

--- a/src/utils/score.ts
+++ b/src/utils/score.ts
@@ -14,9 +14,12 @@ export const INITIAL_SCORE: Score = {
 
 const CP_CEILING = 1000;
 
-export function formatScore(score: ScoreValue, precision = 2): string {
+export function formatScore(score: ScoreValue): string {
   let scoreText = match(score.type)
-    .with("cp", () => Math.abs(score.value / 100).toFixed(precision))
+    // yoinked from: https://github.com/lichess-org/lila/blob/e110605c138c1f6fec417ab9317968b32a928a16/ui/ceval/src/util.ts#L8
+    .with("cp", () =>
+      Math.min(Math.round(Math.abs(score.value) / 10) / 10, 99).toFixed(1),
+    )
     .with("mate", () => `M${Math.abs(score.value)}`)
     .with("dtz", () => `DTZ${Math.abs(score.value)}`)
     .exhaustive();

--- a/src/utils/tests/score.test.ts
+++ b/src/utils/tests/score.test.ts
@@ -8,11 +8,15 @@ import {
 } from "../score";
 
 test("should format a positive cp score correctly", () => {
-  expect(formatScore({ type: "cp", value: 50 })).toBe("+0.50");
+  expect(formatScore({ type: "cp", value: 50 })).toBe("+0.5");
 });
 
 test("should format a negative cp score correctly", () => {
-  expect(formatScore({ type: "cp", value: -50 })).toBe("-0.50");
+  expect(formatScore({ type: "cp", value: -50 })).toBe("-0.5");
+});
+
+test("should format a large cp score correctly", () => {
+  expect(formatScore({ type: "cp", value: 12345.67 })).toBe("+99.0");
 });
 
 test("should format a mate score correctly", () => {


### PR DESCRIPTION
- truncated formatted score
uses lila's score formatting
See: https://github.com/lichess-org/lila/blob/e110605c138c1f6fec417ab9317968b32a928a16/ui/ceval/src/util.ts#L8
- Eval Bar: disabled overflow
- Score Bubble: disabled overflow
- Score Bubble: added tooltip
