### PR TITLE
fix: trim query strings of lichess game URL

### DIFF
--- a/src/components/tabs/ImportModal.tsx
+++ b/src/components/tabs/ImportModal.tsx
@@ -119,7 +119,7 @@ export default function ImportModal({
       if (link.includes("chess.com")) {
         pgn = await getChesscomGame(link);
       } else if (link.includes("lichess")) {
-        const gameId = link.split("/")[3];
+        const gameId = link.split("/")[3].split("?")[0];
         pgn = await getLichessGame(gameId);
       }
 


### PR DESCRIPTION
This PR trims the query strings of the lichess game URL so that PGN URLs can also be imported instead of regular URLs.
![image](https://github.com/franciscoBSalgueiro/en-croissant/assets/61998307/6315dbf1-eee3-4ef3-80ea-971493ebbff3)
(General URL: blue square, PGN URL: red square)