### PR TITLE
Persist files datatable sorting across view loads

### DIFF
--- a/src/components/files/DirectoryTable.tsx
+++ b/src/components/files/DirectoryTable.tsx
@@ -59,10 +59,15 @@ function recursiveSort(
 
 type SortStatus = DataTableSortStatus<MetadataOrEntry>;
 const sortStatusStorageId = `${DirectoryTable.name}-sort-status` as const;
-const sortStatusAtom = atomWithStorage<SortStatus>(sortStatusStorageId, {
-  columnAccessor: "lastModified",
-  direction: "desc",
-}, undefined, { getOnInit: true });
+const sortStatusAtom = atomWithStorage<SortStatus>(
+  sortStatusStorageId,
+  {
+    columnAccessor: "lastModified",
+    direction: "desc",
+  },
+  undefined,
+  { getOnInit: true },
+);
 
 export default function DirectoryTable({
   files,

--- a/src/components/files/DirectoryTable.tsx
+++ b/src/components/files/DirectoryTable.tsx
@@ -171,9 +171,7 @@ function Table({
   selected: FileMetadata | null;
   setSelectedFile: (file: FileMetadata) => void;
   sort: DataTableSortStatus<MetadataOrEntry>;
-  setSort: React.Dispatch<
-    React.SetStateAction<DataTableSortStatus<MetadataOrEntry>>
-  >;
+  setSort: React.Dispatch<SortStatus>;
 }) {
   const { t } = useTranslation();
 


### PR DESCRIPTION
Replaces `useState` for sort with `atomWithStorage` & `useAtom` to persist the sort status to local storage.