### PR TITLE
Implement clearing of drawables with mouse

### DIFF
--- a/src/chessground/Chessground.tsx
+++ b/src/chessground/Chessground.tsx
@@ -16,7 +16,19 @@ export function Chessground(
   const moveMethod = useAtomValue(moveMethodAtom);
 
   useEffect(() => {
-    if (ref?.current && !api) {
+    if (ref?.current == null) return;
+    if (api) {
+      api?.set({
+        ...props,
+        events: {
+          change: () => {
+            if (props.setBoardFen && api) {
+              props.setBoardFen(api.getFen());
+            }
+          },
+        },
+      });
+    } else {
       const chessgroundApi = NativeChessground(ref.current, {
         ...props,
         events: {
@@ -36,17 +48,6 @@ export function Chessground(
         },
       });
       setApi(chessgroundApi);
-    } else if (ref?.current && api) {
-      api?.set({
-        ...props,
-        events: {
-          change: () => {
-            if (props.setBoardFen && api) {
-              props.setBoardFen(api.getFen());
-            }
-          },
-        },
-      });
     }
   }, [api, props, ref]);
 

--- a/src/components/boards/Board.tsx
+++ b/src/components/boards/Board.tsx
@@ -46,6 +46,7 @@ import {
   IconDeviceFloppy,
   IconEdit,
   IconEditOff,
+  IconEraser,
   IconPlus,
   IconSwitchVertical,
   IconTarget,
@@ -62,7 +63,7 @@ import {
 import { chessgroundDests, chessgroundMove } from "chessops/compat";
 import { makeSan } from "chessops/san";
 import { useAtom, useAtomValue } from "jotai";
-import { memo, useContext, useMemo, useState } from "react";
+import { memo, useContext, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useTranslation } from "react-i18next";
 import { match } from "ts-pattern";
@@ -322,6 +323,15 @@ function Board({
             ) : (
               <IconZoomCheck size="1.3rem" />
             )}
+          </ActionIcon>
+        </Tooltip>
+        <Tooltip label="Clear Drawings">
+          <ActionIcon
+            variant={editingMode ? "filled" : "default"}
+            size="lg"
+            onClick={() => setShapes([])}
+          >
+            <IconEraser size="1.3rem" />
           </ActionIcon>
         </Tooltip>
         {!disableVariations && (

--- a/src/components/boards/Board.tsx
+++ b/src/components/boards/Board.tsx
@@ -7,6 +7,7 @@ import {
   currentTabAtom,
   deckAtomFamily,
   enableBoardScrollAtom,
+  eraseDrawablesOnClickAtom,
   forcedEnPassantAtom,
   moveInputAtom,
   showArrowsAtom,
@@ -63,7 +64,7 @@ import {
 import { chessgroundDests, chessgroundMove } from "chessops/compat";
 import { makeSan } from "chessops/san";
 import { useAtom, useAtomValue } from "jotai";
-import { memo, useContext, useMemo, useRef, useState } from "react";
+import { memo, useContext, useMemo, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useTranslation } from "react-i18next";
 import { match } from "ts-pattern";
@@ -153,6 +154,7 @@ function Board({
   const showDests = useAtomValue(showDestsAtom);
   const showArrows = useAtomValue(showArrowsAtom);
   const showConsecutiveArrows = useAtomValue(showConsecutiveArrowsAtom);
+  const eraseDrawablesOnClick = useAtomValue(eraseDrawablesOnClickAtom);
   const autoPromote = useAtomValue(autoPromoteAtom);
   const forcedEP = useAtomValue(forcedEnPassantAtom);
   const showCoordinates = useAtomValue(showCoordinatesAtom);
@@ -325,15 +327,17 @@ function Board({
             )}
           </ActionIcon>
         </Tooltip>
-        <Tooltip label="Clear Drawings">
-          <ActionIcon
-            variant={editingMode ? "filled" : "default"}
-            size="lg"
-            onClick={() => setShapes([])}
-          >
-            <IconEraser size="1.3rem" />
-          </ActionIcon>
-        </Tooltip>
+        {!eraseDrawablesOnClick && (
+          <Tooltip label="Clear Drawings">
+            <ActionIcon
+              variant={editingMode ? "filled" : "default"}
+              size="lg"
+              onClick={() => setShapes([])}
+            >
+              <IconEraser size="1.3rem" />
+            </ActionIcon>
+          </Tooltip>
+        )}
         {!disableVariations && (
           <Tooltip label="Edit Position">
             <ActionIcon
@@ -598,6 +602,9 @@ function Board({
               }
               className={chessboard}
               ref={boardRef}
+              onClick={() => {
+                eraseDrawablesOnClick && setShapes([]);
+              }}
               onWheel={(e) => {
                 if (enableBoardScroll) {
                   if (e.deltaY > 0) {

--- a/src/components/boards/Board.tsx
+++ b/src/components/boards/Board.tsx
@@ -145,6 +145,7 @@ function Board({
   const storeMakeMove = useStore(store, (s) => s.makeMove);
   const setHeaders = useStore(store, (s) => s.setHeaders);
   const deleteMove = useStore(store, (s) => s.deleteMove);
+  const clearShapes = useStore(store, (s) => s.clearShapes);
   const setShapes = useStore(store, (s) => s.setShapes);
   const setFen = useStore(store, (s) => s.setFen);
 
@@ -332,7 +333,7 @@ function Board({
             <ActionIcon
               variant={editingMode ? "filled" : "default"}
               size="lg"
-              onClick={() => setShapes([])}
+              onClick={() => clearShapes()}
             >
               <IconEraser size="1.3rem" />
             </ActionIcon>
@@ -603,7 +604,7 @@ function Board({
               className={chessboard}
               ref={boardRef}
               onClick={() => {
-                eraseDrawablesOnClick && setShapes([]);
+                eraseDrawablesOnClick && clearShapes();
               }}
               onWheel={(e) => {
                 if (enableBoardScroll) {

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -1,8 +1,8 @@
-import type { Dirs } from "@/App";
 import {
   autoPromoteAtom,
   autoSaveAtom,
   enableBoardScrollAtom,
+  eraseDrawablesOnClickAtom,
   forcedEnPassantAtom,
   minimumGamesAtom,
   moveInputAtom,
@@ -221,6 +221,20 @@ export default function Page() {
                   </Text>
                 </div>
                 <SettingsSwitch atom={showConsecutiveArrowsAtom} />
+              </Group>
+              <Group
+                justify="space-between"
+                wrap="nowrap"
+                gap="xl"
+                className={classes.item}
+              >
+                <div>
+                  <Text>{t("Settings.EraseDrawablesOnClick")}</Text>
+                  <Text size="xs" c="dimmed">
+                    {t("Settings.EraseDrawablesOnClick.Desc")}
+                  </Text>
+                </div>
+                <SettingsSwitch atom={eraseDrawablesOnClickAtom} />
               </Group>
               <Group
                 justify="space-between"

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -130,6 +130,10 @@ export const showConsecutiveArrowsAtom = atomWithStorage<boolean>(
   "show-consecutive-arrows",
   false,
 );
+export const eraseDrawablesOnClickAtom = atomWithStorage<boolean>(
+  "erase-drawables-on-click",
+  false,
+);
 export const autoPromoteAtom = atomWithStorage<boolean>("auto-promote", true);
 export const autoSaveAtom = atomWithStorage<boolean>("auto-save", true);
 export const previewBoardOnHoverAtom = atomWithStorage<boolean>(

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -468,9 +468,9 @@ export const createTreeStore = (id?: string, initialTree?: TreeState) => {
     clearShapes: () =>
       set(
         produce((state) => {
-          state.dirty = true;
           const node = getNodeAtPath(state.root, state.position);
-          if (node) {
+          if (node && node.shapes.length > 0) {
+            state.dirty = true;
             node.shapes = [];
           }
         }),

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -640,16 +640,23 @@ function promoteVariation(state: TreeState, path: number[]) {
 function setShapes(state: TreeState, shapes: DrawShape[]) {
   const node = getNodeAtPath(state.root, state.position);
   if (!node) return state;
-  const shape = shapes[0];
-  const index = node.shapes.findIndex(
-    (s) => s.orig === shape.orig && s.dest === shape.dest,
-  );
 
-  if (index !== -1) {
-    node.shapes.splice(index, 1);
+  const [shape] = shapes;
+  if (shape) {
+    const index = node.shapes.findIndex(
+      (s) => s.orig === shape.orig && s.dest === shape.dest,
+    );
+
+    if (index !== -1) {
+      node.shapes.splice(index, 1);
+    } else {
+      node.shapes.push(shape);
+    }
   } else {
-    node.shapes.push(shape);
+    node.shapes = [];
   }
+
+  return state;
 }
 
 function addAnalysis(

--- a/src/translation/en_US.ts
+++ b/src/translation/en_US.ts
@@ -286,6 +286,9 @@ export const en_US = {
     "Settings.ConsecutiveArrows": "Consecutive Arrows",
     "Settings.ConsecutiveArrows.Desc":
       "Show multiple arrows for the best line, if it involves moving the same piece several times",
+    "Settings.EraseDrawablesOnClick": "Erase Drawables On Click",
+    "Settings.EraseDrawablesOnClick.Desc":
+      "Clear the board of drawn arrows & circles by left-clicking the mouse",
     "Settings.AutoPromition": "Auto Promotion",
     "Settings.AutoPromition.Desc":
       "Automatically promote to a queen when a pawn reaches the last rank",

--- a/src/translation/pt_PT.ts
+++ b/src/translation/pt_PT.ts
@@ -285,6 +285,9 @@ export const pt_PT = {
     "Settings.ConsecutiveArrows": "Setas consecutivas",
     "Settings.ConsecutiveArrows.Desc":
       "Mostra várias setas para a melhor linha, caso ela consista em mover a mesma peça várias vezes",
+    "Settings.EraseDrawablesOnClick": "Apagar desenháveis ao clicar",
+    "Settings.EraseDrawablesOnClick.Desc":
+      "Limpe o tabuleiro de setas e círculos desenhados clicando com o botão esquerdo do mouse",
     "Settings.AutoPromition": "Auto Promoção",
     "Settings.AutoPromition.Desc": "Automaticamente promover para rainha",
     "Settings.Coordinates": "Coordenadas",

--- a/src/translation/pt_PT.ts
+++ b/src/translation/pt_PT.ts
@@ -285,9 +285,9 @@ export const pt_PT = {
     "Settings.ConsecutiveArrows": "Setas consecutivas",
     "Settings.ConsecutiveArrows.Desc":
       "Mostra várias setas para a melhor linha, caso ela consista em mover a mesma peça várias vezes",
-    "Settings.EraseDrawablesOnClick": "Apagar desenháveis ao clicar",
+    "Settings.EraseDrawablesOnClick": "Apagar desenhos ao clicar",
     "Settings.EraseDrawablesOnClick.Desc":
-      "Limpe o tabuleiro de setas e círculos desenhados clicando com o botão esquerdo do mouse",
+      "Limpar o tabuleiro das setas e círculos desenhados ao clicar com o botão esquerdo do rato",
     "Settings.AutoPromition": "Auto Promoção",
     "Settings.AutoPromition.Desc": "Automaticamente promover para rainha",
     "Settings.Coordinates": "Coordenadas",

--- a/src/translation/zh_CN.ts
+++ b/src/translation/zh_CN.ts
@@ -280,6 +280,9 @@ export const zh_CN = {
     "Settings.ConsecutiveArrows": "连续箭头",
     "Settings.ConsecutiveArrows.Desc":
       "如果最佳着法中会多次移动同一个棋子，显示多个箭头",
+    "Settings.EraseDrawablesOnClick": "单击时擦除可绘制对象",
+    "Settings.EraseDrawablesOnClick.Desc":
+      "通过单击鼠标左键清除棋盘上绘制的箭头和圆圈",
     "Settings.AutoPromition": "自动升变",
     "Settings.AutoPromition.Desc": "兵抵达底线时自动升变为后",
     "Settings.Coordinates": "坐标",


### PR DESCRIPTION
Removing drawables one-by-one is tedious. This affords an easy way to clear them by:

1. Implementing a "Clear Drawings" button on the Board component
2. Implementing a setting to clear the board on left-click, replicating e.g. Chess.com behavior

If the setting is enabled, the "Clear Drawings" button will not be rendered.

Translations for the setting were done with Google Translate.