### PR TITLE
Add "Random Game" button

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -51,7 +51,7 @@ use crate::puzzle::{get_puzzle, get_puzzle_db_info};
 use crate::{
     chess::get_best_moves,
     db::{
-        delete_duplicated_games, edit_db_info, get_db_info, get_games, get_players, merge_players,
+        delete_duplicated_games, edit_db_info, get_db_info, get_games, get_random_game, get_players, merge_players,
     },
     fs::{download_file, file_exists, get_file_metadata},
     opening::{get_opening_from_fen, get_opening_from_name, search_opening_name},
@@ -263,6 +263,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             download_file,
             get_games,
+            get_random_game,
             get_players,
             get_tournaments,
             get_db_info,

--- a/src/components/databases/DatabasesPage.tsx
+++ b/src/components/databases/DatabasesPage.tsx
@@ -342,7 +342,7 @@ export default function DatabasesPage() {
                         rightSection={<IconArrowRight size="1rem" />}
                         variant="default"
                         onClick={async () => {
-                          let data = await get_random_game(selectedDatabase.file);
+                          let data = await get_random_game(selectedDatabase.file, selectedDatabase.game_count);
                           let games = data?.data ?? [];
                           const record = games[0];
 

--- a/src/translation/en_US.ts
+++ b/src/translation/en_US.ts
@@ -248,6 +248,7 @@ export const en_US = {
     "Databases.Settings.Actions": "Actions",
     "Databases.Settings.AddGames": "Add Games",
     "Databases.Settings.ExportPGN": "Export to PGN",
+    "Databases.Settings.RandomGame": "Random Game",
     "Databases.Delete.Title": "Delete Database",
     "Databases.Delete.Message":
       "Are you sure you want to delete this database?",

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -119,9 +119,10 @@ export async function query_games(
 }
 
 export async function get_random_game(
-  db: string
+  db: string,
+  count: number
 ): Promise<QueryResponse<NormalizedGame[]>> {
-  return invoke("get_random_game", {file: db});
+  return invoke("get_random_game", {file: db, count: count});
 
 }
 

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -118,6 +118,14 @@ export async function query_games(
   });
 }
 
+export async function get_random_game(
+  db: string
+): Promise<QueryResponse<NormalizedGame[]>> {
+  return invoke("get_random_game", {file: db});
+
+}
+
+
 interface PlayerQuery extends Query {
   name?: string;
   range?: [number, number];


### PR DESCRIPTION
Feature Added: A new button labeled "Random Game" was added to the database settings screen.

Functionality: Clicking the button will open a tab containing a random game from the database.

Use Case: It is quite useful for very large databases to avoid Analysis Paralysis in deciding which game to open, also in viewing game collections, where you want to select a random unbiased game.

Testing: The feature was tested on a 1.5M games database, and it loads relatively quickly.

