### PR TITLE
Accept alternate Mate-in-1 in puzzle mode

### DIFF
--- a/src/components/puzzles/PuzzleBoard.tsx
+++ b/src/components/puzzles/PuzzleBoard.tsx
@@ -89,7 +89,7 @@ function PuzzleBoard({
     const uci = makeUci(move);
     newPos.play(move);
 
-    if (puzzle.moves[currentMove] === uci) {
+    if (puzzle.moves[currentMove] === uci || newPos.isCheckmate()) {
       if (currentMove === puzzle.moves.length - 1) {
         if (puzzle.completion !== "incorrect") {
           changeCompletion("correct");


### PR DESCRIPTION
fixes franciscoBSalgueiro#383

position `r1b2k1r/1p1n2p1/p2q1b1p/2Bp1p1Q/5P2/6P1/PP3NBP/R3R2K b - - 1 22` `1... Nxc5` now accepts both `2. Re8#` and `2. Qe8#`