### PR TITLE
fix: prevent moves after puzzle completion

### DIFF
--- a/src/components/puzzles/PuzzleBoard.tsx
+++ b/src/components/puzzles/PuzzleBoard.tsx
@@ -146,7 +146,9 @@ function PuzzleBoard({
           movable={{
             free: false,
             color:
-              puzzle && equal(position, Array(currentMove).fill(0))
+              puzzle &&
+              equal(position, Array(currentMove).fill(0)) &&
+              puzzle.completion === "incomplete"
                 ? turn
                 : undefined,
             dests: dests,


### PR DESCRIPTION
Stops accepting moves once a puzzle is completed
Fixes #384