### PR TITLE
fix: black incorrectly starting with increment time

### DIFF
--- a/src/components/boards/BoardGame.tsx
+++ b/src/components/boards/BoardGame.tsx
@@ -569,7 +569,13 @@ function BoardGame() {
       }
       if (pos?.turn === "white" && blackTime !== null) {
         setBlackTime(
-          (prev) => prev! + (players.black.timeControl?.increment ?? 0),
+          (prev) => {
+            if (pos?.fullmoves === 1) {
+              return prev!;
+            }
+
+            return prev! + (players.black.timeControl?.increment ?? 0);
+          }
         );
       }
       setIntervalId(intervalId);


### PR DESCRIPTION
This fixes #433 when starting a new game, black's initial clock doesn't get incremented before his move