### PR TITLE
Fixed settings of Tauri capabilities to have access to $APPDATA

### DIFF
--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -26,7 +26,7 @@
             "identifier": "fs:scope-appdata-recursive",
             "allow": [
                 {
-                    "path": "$APPDATA/**"
+                    "path": "**"
                 }
             ]
         },

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -23,10 +23,10 @@
         "fs:write-all",
         "window-state:default",
         {
-            "identifier": "fs:scope",
+            "identifier": "fs:scope-appdata-recursive",
             "allow": [
                 {
-                    "path": "**"
+                    "path": "$APPDATA/**"
                 }
             ]
         },


### PR DESCRIPTION
I have noticed you have switched on Tauri V2. It's nice because prev version work on my system with lags. Unformatelly, on my system (Ubuntu 24) master branch just doesn't work properly. App doesn't have access to APPDATA. 