### PR TITLE
Preserve FEN when changing orientation

### DIFF
--- a/src/components/boards/Board.tsx
+++ b/src/components/boards/Board.tsx
@@ -189,6 +189,7 @@ function Board({
   const toggleOrientation = () =>
     setHeaders({
       ...headers,
+      fen: currentNode.fen, // To keep the current board setup
       orientation: orientation === "black" ? "white" : "black",
     });
 

--- a/src/components/boards/Board.tsx
+++ b/src/components/boards/Board.tsx
@@ -189,7 +189,7 @@ function Board({
   const toggleOrientation = () =>
     setHeaders({
       ...headers,
-      fen: currentNode.fen, // To keep the current board setup
+      fen: root.fen, // To keep the current board setup
       orientation: orientation === "black" ? "white" : "black",
     });
 


### PR DESCRIPTION
Fixes #397 to an extent.

The board setup will be kept, but the list of moves still reset when flipping the board (although that's the case even if we're not in edit mode).