### PR TITLE
Prevent crash when a player runs out of time

### DIFF
--- a/src/components/boards/BoardGame.tsx
+++ b/src/components/boards/BoardGame.tsx
@@ -317,6 +317,7 @@ function BoardGame() {
   const headers = useStore(store, (s) => s.headers);
   const setFen = useStore(store, (s) => s.setFen);
   const setHeaders = useStore(store, (s) => s.setHeaders);
+  const setResult = useStore(store, (s) => s.setResult);
   const appendMove = useStore(store, (s) => s.appendMove);
 
   const [, setTabs] = useAtom(tabsAtom);
@@ -452,17 +453,10 @@ function BoardGame() {
 
   useEffect(() => {
     if (gameState === "playing" && whiteTime !== null && whiteTime <= 0) {
-      if (intervalId) {
-        clearInterval(intervalId);
-      }
-      setIntervalId(null);
       setGameState("gameOver");
-      setHeaders({
-        ...headers,
-        result: "0-1",
-      });
+      setResult("0-1");
     }
-  }, [gameState, whiteTime, setGameState, setHeaders, headers]);
+  }, [gameState, whiteTime, setGameState, setResult]);
 
   useEffect(() => {
     if (gameState !== "playing") {
@@ -476,18 +470,17 @@ function BoardGame() {
   useEffect(() => {
     if (gameState === "playing" && blackTime !== null && blackTime <= 0) {
       setGameState("gameOver");
-      setHeaders({
-        ...headers,
-        result: "1-0",
-      });
+      setResult("1-0");
     }
-  }, [gameState, blackTime, setGameState, setHeaders, headers]);
+  }, [gameState, blackTime, setGameState, setResult]);
 
   function decrementTime() {
-    if (pos?.turn === "white" && whiteTime !== null) {
-      setWhiteTime((prev) => prev! - 100);
-    } else if (pos?.turn === "black" && blackTime !== null) {
-      setBlackTime((prev) => prev! - 100);
+    if (gameState === "playing") {
+      if (pos?.turn === "white" && whiteTime !== null) {
+        setWhiteTime((prev) => prev! - 100);
+      } else if (pos?.turn === "black" && blackTime !== null) {
+        setBlackTime((prev) => prev! - 100);
+      }
     }
   }
 

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,4 +1,4 @@
-import type { BestMoves, Score } from "@/bindings";
+import type { BestMoves, Outcome, Score } from "@/bindings";
 import { ANNOTATION_INFO, type Annotation } from "@/utils/annotation";
 import { getPGN } from "@/utils/chess";
 import { parseSanOrUci, positionFromFen } from "@/utils/chessops";
@@ -72,6 +72,7 @@ export interface TreeStoreState {
   setAnnotation: (payload: Annotation) => void;
   setComment: (payload: string) => void;
   setHeaders: (payload: GameHeaders) => void;
+  setResult: (payload: Outcome) => void;
   setShapes: (shapes: DrawShape[]) => void;
   setScore: (score: Score) => void;
 
@@ -438,6 +439,13 @@ export const createTreeStore = (id?: string, initialTree?: TreeState) => {
             state.root = defaultTree(headers.fen).root;
             state.position = [];
           }
+        }),
+      ),
+    setResult: (result) =>
+      set(
+        produce((state) => {
+          state.dirty = true;
+          state.headers.result = result;
         }),
       ),
     setShapes: (shapes) =>


### PR DESCRIPTION
The play screen currently crashes when a player runs out of time because it goes into an infinite loop updating the header;
this PR fixes that by updating the result directly.

I've also removed redundantant code that clears the interval twice and prevented the time from being decremented after the game has ended.

Closes #464
Closes #455 
Closes #430
Closes #366
