### PR TITLE
ci: update github workflows

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,26 +11,40 @@ on:
 
 jobs:
   release:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-13, ubuntu-20.04, windows-latest]
+        include:
+          - platform: 'macos-latest' # for Arm based macs (M1 and above).
+            args: '--target aarch64-apple-darwin --bundles dmg'
+          - platform: 'macos-latest' # for Intel based macs.
+            args: '--target x86_64-apple-darwin --bundles dmg'
+          - platform: 'ubuntu-22.04'
+            args: ''
+          - platform: 'windows-latest'
+            args: '--bundles nsis'
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
       - name: Install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-20.04'
+        if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libayatana-appindicator3-dev librsvg2-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Rust setup
         uses: dtolnay/rust-toolchain@stable
+        with:
+          # Only install macos targets on macos runners
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2.7.3
+        uses: swatinem/rust-cache@v2
         with:
           workspaces: "./src-tauri -> target"
 
@@ -55,9 +69,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          CI: false
         with:
           tagName: ${{ github.ref_name }}-beta
           releaseName: "v__VERSION__-beta"
           releaseBody: "See the assets to download and install this version."
           releaseDraft: false
           prerelease: true
+          args: ${{ matrix.args }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,26 +7,39 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-13, ubuntu-20.04, windows-latest]
+        include:
+          - platform: 'macos-latest' # for Arm based macs (M1 and above).
+            args: '--target aarch64-apple-darwin --bundles dmg'
+          - platform: 'macos-latest' # for Intel based macs.
+            args: '--target x86_64-apple-darwin --bundles dmg'
+          - platform: 'ubuntu-22.04'
+            args: ''
+          - platform: 'windows-latest'
+            args: '--bundles nsis'
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-20.04'
+        if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libayatana-appindicator3-dev librsvg2-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Rust setup
         uses: dtolnay/rust-toolchain@stable
+        with:
+          # Only install macos targets on macos runners
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2.7.3
+        uses: swatinem/rust-cache@v2
         with:
           workspaces: "./src-tauri -> target"
 
@@ -51,9 +64,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          CI: false
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "v__VERSION__"
           releaseBody: "See the assets to download and install this version."
           releaseDraft: true
           prerelease: false
+          args: ${{ matrix.args }}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
       "exceptionDomain": "",
       "frameworks": [],
       "providerShortName": null,
-      "signingIdentity": null
+      "signingIdentity": "-"
     },
     "resources": [],
     "targets": "all",


### PR DESCRIPTION
Adds adhoc code signing for MacOS bundles which allows the aarch64 build to run after being allowed in the "Privacy and Security" settings tab. Updates the prerelease and release Github workflows with the following changes:

general
* allow prerelease workflow to be run manually
* explicitly set workflow permissions
* unpin swatinem/rust-cache version (Cargo.lock version 4 support)
* only install macos rust targets on macos runners
* pass args to build step

macos
* update runner to macos-latest
* build for intel and aarch64
* only build dmg bundles (https://github.com/tauri-apps/tauri/issues/5890)
* disable tauri build ci flag (https://github.com/tauri-apps/tauri-action/issues/740)

windows
* only build exe bundle

linux
* update runner to ubuntu-22.04 
* update dependencies for tauri 2.0

Fixes: https://github.com/franciscoBSalgueiro/en-croissant/issues/392