### PR TITLE
fix: download percentage NaN

### DIFF
--- a/src/components/home/AccountCard.tsx
+++ b/src/components/home/AccountCard.tsx
@@ -143,7 +143,7 @@ export function AccountCard({
 
   const downloadedGames =
     database?.type === "success" ? database.game_count : 0;
-  const percentage = ((downloadedGames / total) * 100).toFixed(2);
+  const percentage = total === 0 || downloadedGames === 0 ? "0" : ((downloadedGames / total) * 100).toFixed(2);
 
   async function getLastGameDate({
     database,
@@ -256,7 +256,7 @@ export function AccountCard({
 
               <div>
                 <Tooltip label={`${downloadedGames} games`}>
-                  <Text fw="bold">{percentage}%</Text>
+                    <Text fw="bold">{percentage === "0" ? "0" : `${percentage}%`}</Text>
                 </Tooltip>
                 <Text size="xs" c="dimmed">
                   Downloaded


### PR DESCRIPTION
This change fixes an issue where the download percentage for accounts with no games played was showing as "NaN%". Now, if the total number of games or the number of downloaded games is zero, it will show as 0 Downloaded. For all other cases, the percentage will still be calculated and shown as before.
  
Fixes https://github.com/franciscoBSalgueiro/en-croissant/issues/336