### PR TITLE
docs: add install instructions for pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ En-Croissant is an open-source, cross-platform chess GUI that aims to be powerfu
 
 Refer to the [Tauri documentation](https://tauri.app/v1/guides/getting-started/prerequisites) for the requirements on your platform.
 
+En-Croissant uses pnpm as the package manager for dependencies. Refer to the [pnpm install instructions](https://pnpm.io/installation) for how to install it on your platform.
+
 ```bash
 git clone https://github.com/franciscoBSalgueiro/en-croissant
 cd en-croissant


### PR DESCRIPTION
I was about to try En Croissant, but couldn't run the installer.
So I decided to build it, but had no idea what pnpm was (today I learned, though).
I've opened this Pull Request to make it clearer that pnpm is a requirement for the build and linked to their installation instructions.