### PR TITLE
fix: prevent infinite loop in promoteToMainline (causing #496)

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -377,7 +377,10 @@ export const createTreeStore = (id?: string, initialTree?: TreeState) => {
       set(
         produce((state) => {
           state.dirty = true;
-          while (!promoteVariation(state, path)) {}
+          while (path.some((v) => v !== 0)) {
+            promoteVariation(state, path);
+            path = state.position;
+          }
         }),
       ),
     copyVariationPgn: (path) => {


### PR DESCRIPTION
Bug #496 was caused by repeatedly using the same path for promotion without updating it after each step. Now correctly updates the path with state.position after each promotion until the variation reaches the main line.