### PR TITLE
Enhance GameNotation and Comment components

### DIFF
--- a/src/components/common/Comment.tsx
+++ b/src/components/common/Comment.tsx
@@ -1,5 +1,4 @@
 import { TypographyStylesProvider } from "@mantine/core";
-
 import Markdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
@@ -10,16 +9,25 @@ export function Comment({ comment }: { comment: string }) {
 
   return (
     <TypographyStylesProvider
-      pl={0}
-      mx={4}
       style={{
-        display: multipleLine ? "block" : "inline-block",
+        display: multipleLine ? "block" : "inline",
+        lineHeight: multipleLine ? undefined : "inherit",
       }}
     >
       <Markdown
         components={{
           a: ({ node, ...props }) => (
             <a {...props} target="_blank" rel="noreferrer" />
+          ),
+          p: ({ children }) => (
+            <span
+              style={{
+                display: multipleLine ? "block" : "inline",
+                marginBottom: multipleLine ? undefined : 0,
+              }}
+            >
+              {children}
+            </span>
           ),
         }}
         rehypePlugins={[rehypeRaw, remarkGfm]}

--- a/src/components/common/GameNotation.tsx
+++ b/src/components/common/GameNotation.tsx
@@ -2,7 +2,7 @@ import { Comment } from "@/components/common/Comment";
 import { TreeStateContext } from "@/components/common/TreeStateContext";
 import { currentInvisibleAtom } from "@/state/atoms";
 import { keyMapAtom } from "@/state/keybinds";
-import { type TreeNode, getNodeAtPath } from "@/utils/treeReducer";
+import type { TreeNode } from "@/utils/treeReducer";
 import {
   ActionIcon,
   Box,
@@ -14,6 +14,8 @@ import {
   Stack,
   Text,
   Tooltip,
+  rgba,
+  useMantineTheme,
 } from "@mantine/core";
 import { useColorScheme, useToggle } from "@mantine/hooks";
 import {
@@ -21,52 +23,113 @@ import {
   IconArrowsSplit,
   IconArticle,
   IconArticleOff,
+  IconChevronDown,
+  IconChevronRight,
   IconEye,
   IconEyeOff,
-  IconMinus,
-  IconPlus,
+  IconListTree,
+  IconPoint,
+  IconPointFilled,
 } from "@tabler/icons-react";
 import { INITIAL_FEN } from "chessops/fen";
 import equal from "fast-deep-equal";
 import { useAtom, useAtomValue } from "jotai";
-import { memo, useContext, useEffect, useRef, useState } from "react";
-import React from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useStore } from "zustand";
 import CompleteMoveCell from "./CompleteMoveCell";
 import * as styles from "./GameNotation.css";
+import * as moveStyles from "./MoveCell.css";
 import OpeningName from "./OpeningName";
 
+type VariationState = "mainline" | "variations" | "repertoire";
+
+const variationRefs = {
+  mainline: React.createRef<HTMLSpanElement>(),
+  variations: React.createRef<HTMLSpanElement>(),
+  repertoire: React.createRef<HTMLSpanElement>(),
+};
+
+function isOnNextDivergenceFromMainline(
+  node: TreeNode,
+  remainingPath: number[],
+): boolean {
+  if (remainingPath.length === 0) return false;
+  if (!node.children) return false;
+  if (node.children.length > 1) {
+    if (remainingPath[0] > node.children.length) return false;
+    return remainingPath[0] !== 0;
+  }
+  const nextNode = node.children[remainingPath[0]];
+  if (!nextNode) return false;
+  return isOnNextDivergenceFromMainline(nextNode, remainingPath.slice(1));
+}
+
+function hasMultipleChildrenInChain(node: TreeNode): boolean {
+  if (!node.children) return false;
+  if (node.children.length > 1) return true;
+  if (node.children.length === 1) {
+    return hasMultipleChildrenInChain(node.children[0]);
+  }
+  return false;
+}
+
+function hasMultipleChildrenUntilPosition(
+  node: TreeNode,
+  remainingPath: number[],
+): boolean {
+  if (remainingPath.length === 0) return false;
+  if (!node.children) return false;
+  if (node.children.length > 1) return true;
+  const nextNode = node.children[remainingPath[0]];
+  if (!nextNode) return false;
+  return hasMultipleChildrenUntilPosition(nextNode, remainingPath.slice(1));
+}
+
 function GameNotation({ topBar }: { topBar?: boolean }) {
-  const store = useContext(TreeStateContext)!;
+  const store = useContext(TreeStateContext);
+  if (!store) {
+    throw new Error("GameNotation must be used within a TreeStateProvider");
+  }
+
   const root = useStore(store, (s) => s.root);
   const currentFen = useStore(store, (s) => s.currentNode().fen);
+  const position = useStore(store, (s) => s.position);
   const headers = useStore(store, (s) => s.headers);
 
   const viewport = useRef<HTMLDivElement>(null);
-  const targetRef = useRef<HTMLSpanElement>(null);
+
+  const [invisibleValue, setInvisible] = useAtom(currentInvisibleAtom);
+  const [variationState, toggleVariationState] = useToggle([
+    "mainline",
+    "variations",
+    "repertoire",
+  ]) as [VariationState, () => void];
+  const [showComments, toggleComments] = useToggle([true, false]);
+
+  const invisible = topBar && invisibleValue;
+  const colorScheme = useColorScheme();
+  const keyMap = useAtomValue(keyMapAtom);
+
+  useHotkeys(keyMap.TOGGLE_BLUR.keys, () =>
+    setInvisible((prev: boolean) => !prev),
+  );
 
   useEffect(() => {
     if (viewport.current) {
       if (currentFen === INITIAL_FEN) {
         viewport.current.scrollTo({ top: 0, behavior: "smooth" });
-      } else if (targetRef.current) {
-        viewport.current.scrollTo({
-          top: targetRef.current.offsetTop - 65,
-          behavior: "smooth",
-        });
+      } else {
+        const currentRef = variationRefs[variationState];
+        if (currentRef?.current) {
+          viewport.current.scrollTo({
+            top: currentRef.current.offsetTop - 65,
+            behavior: "smooth",
+          });
+        }
       }
     }
-  }, [currentFen]);
-
-  const [invisibleValue, setInvisible] = useAtom(currentInvisibleAtom);
-  const invisible = topBar && invisibleValue;
-  const [showVariations, toggleVariations] = useToggle([true, false]);
-  const [showComments, toggleComments] = useToggle([true, false]);
-  const colorScheme = useColorScheme();
-
-  const keyMap = useAtomValue(keyMapAtom);
-  useHotkeys(keyMap.TOGGLE_BLUR.keys, () => setInvisible((v) => !v));
+  }, [currentFen, variationState]);
 
   return (
     <Paper
@@ -80,8 +143,8 @@ function GameNotation({ topBar }: { topBar?: boolean }) {
           <NotationHeader
             showComments={showComments}
             toggleComments={toggleComments}
-            showVariations={showVariations}
-            toggleVariations={toggleVariations}
+            variationState={variationState}
+            toggleVariationState={toggleVariationState}
           />
         )}
         <ScrollArea flex={1} offsetScrollbars viewportRef={viewport}>
@@ -98,16 +161,57 @@ function GameNotation({ topBar }: { topBar?: boolean }) {
               {showComments && root.comment && (
                 <Comment comment={root.comment} />
               )}
-              <RenderVariationTree
-                targetRef={targetRef}
-                tree={root}
-                depth={0}
-                first
-                start={headers.start}
-                showVariations={showVariations}
-                showComments={showComments}
-                path={[]}
-              />
+              <Box
+                style={{
+                  display: variationState === "mainline" ? "block" : "none",
+                }}
+              >
+                <RenderMainline
+                  tree={root}
+                  depth={0}
+                  path={[]}
+                  start={headers.start}
+                  first={true}
+                  showComments={showComments}
+                  targetRef={variationRefs.mainline}
+                  toggleVariationState={toggleVariationState}
+                />
+              </Box>
+              <Box
+                style={{
+                  display: variationState === "variations" ? "block" : "none",
+                }}
+              >
+                <RenderVariations
+                  tree={root}
+                  depth={0}
+                  path={[]}
+                  start={headers.start}
+                  first={true}
+                  showComments={showComments}
+                  renderMoves={false}
+                  nextLevelExpanded={true}
+                  targetRef={variationRefs.variations}
+                  variationState={variationState}
+                  childInPath={false}
+                />
+              </Box>
+              <Box
+                style={{
+                  display: variationState === "repertoire" ? "block" : "none",
+                }}
+              >
+                <RenderRepertoire
+                  tree={root}
+                  depth={0}
+                  path={[]}
+                  start={headers.start}
+                  showComments={showComments}
+                  nextLevelExpanded={true}
+                  targetRef={variationRefs.repertoire}
+                  variationState={variationState}
+                />
+              </Box>
             </Box>
             {headers.result && headers.result !== "*" && (
               <Text ta="center">
@@ -129,30 +233,31 @@ function GameNotation({ topBar }: { topBar?: boolean }) {
   );
 }
 
-const NotationHeader = memo(function NotationHeader({
+function NotationHeader({
   showComments,
   toggleComments,
-  showVariations,
-  toggleVariations,
+  variationState,
+  toggleVariationState,
 }: {
   showComments: boolean;
   toggleComments: () => void;
-  showVariations: boolean;
-  toggleVariations: () => void;
+  variationState: VariationState;
+  toggleVariationState: () => void;
 }) {
   const [invisible, setInvisible] = useAtom(currentInvisibleAtom);
+
   return (
     <Stack>
       <Group justify="space-between">
         <OpeningName />
         <Group gap="sm">
           <Tooltip label={invisible ? "Show moves" : "Hide moves"}>
-            <ActionIcon onClick={() => setInvisible((v) => !v)}>
+            <ActionIcon onClick={() => setInvisible((prev: boolean) => !prev)}>
               {invisible ? <IconEyeOff size="1rem" /> : <IconEye size="1rem" />}
             </ActionIcon>
           </Tooltip>
           <Tooltip label={showComments ? "Hide comments" : "Show comments"}>
-            <ActionIcon onClick={() => toggleComments()}>
+            <ActionIcon onClick={toggleComments}>
               {showComments ? (
                 <IconArticle size="1rem" />
               ) : (
@@ -160,10 +265,20 @@ const NotationHeader = memo(function NotationHeader({
               )}
             </ActionIcon>
           </Tooltip>
-          <Tooltip label={showVariations ? "Show Variations" : "Main line"}>
-            <ActionIcon onClick={() => toggleVariations()}>
-              {showVariations ? (
+          <Tooltip
+            label={
+              variationState === "variations"
+                ? "Show Variations"
+                : variationState === "repertoire"
+                  ? "Repertoire View"
+                  : "Main Line"
+            }
+          >
+            <ActionIcon onClick={toggleVariationState}>
+              {variationState === "variations" ? (
                 <IconArrowsSplit size="1rem" />
+              ) : variationState === "repertoire" ? (
+                <IconListTree size="1rem" />
               ) : (
                 <IconArrowRight size="1rem" />
               )}
@@ -174,124 +289,547 @@ const NotationHeader = memo(function NotationHeader({
       <Divider />
     </Stack>
   );
-});
+}
 
-const RenderVariationTree = memo(
-  function RenderVariationTree({
-    tree,
-    depth,
-    start,
-    first,
-    showVariations,
-    showComments,
-    targetRef,
-    path,
-  }: {
-    start?: number[];
-    tree: TreeNode;
-    depth: number;
-    first?: boolean;
-    showVariations: boolean;
-    showComments: boolean;
-    targetRef: React.RefObject<HTMLSpanElement>;
-    path: number[];
-  }) {
-    const variations = tree.children;
-    const variationNodes = showVariations
-      ? variations.slice(1).map((variation) => {
-          const newPath = [...path, variations.indexOf(variation)];
-          return (
-            <React.Fragment key={variation.fen}>
-              <CompleteMoveCell
-                targetRef={targetRef}
-                annotations={variation.annotations}
-                comment={variation.comment}
-                halfMoves={variation.halfMoves}
-                move={variation.san}
-                fen={variation.fen}
-                movePath={newPath}
-                showComments={showComments}
-                isStart={equal(newPath, start)}
-                first
+function RenderMainline({
+  tree,
+  depth,
+  path,
+  start,
+  first,
+  showComments,
+  targetRef,
+  toggleVariationState,
+}: {
+  tree: TreeNode;
+  depth: number;
+  start?: number[];
+  first?: boolean;
+  showComments: boolean;
+  targetRef: React.RefObject<HTMLSpanElement>;
+  path: number[];
+  toggleVariationState: () => void;
+}) {
+  const variations = tree.children;
+  if (!variations?.length) return null;
+
+  const store = useContext(TreeStateContext);
+  if (!store) {
+    throw new Error("RenderMainline must be used within a TreeStateProvider");
+  }
+  const currentPosition = useStore(store, (s) => s.position);
+  const theme = useMantineTheme();
+
+  const newPath = [...path, 0];
+  const isAtDivergence =
+    currentPosition.length > path.length &&
+    currentPosition.slice(0, path.length).every((v, i) => path[i] === v) &&
+    currentPosition[path.length] > 0;
+
+  return (
+    <>
+      {isAtDivergence && (
+        <Box
+          component="span"
+          style={{
+            display: "inline-block",
+            fontSize: "80%",
+          }}
+        >
+          <Tooltip label="Show variations">
+            <Box
+              component="button"
+              className={moveStyles.cell}
+              onClick={toggleVariationState}
+              style={{
+                backgroundColor: rgba(theme.colors.gray[6], 0.2),
+              }}
+            >
+              <IconArrowsSplit
+                size="1rem"
+                style={{ verticalAlign: "text-bottom" }}
               />
-              <RenderVariationTree
-                targetRef={targetRef}
-                tree={variation}
-                depth={depth + 2}
-                first
-                showVariations={showVariations}
-                showComments={showComments}
-                start={start}
-                path={newPath}
-              />
-            </React.Fragment>
-          );
-        })
-      : [];
+            </Box>
+          </Tooltip>
+        </Box>
+      )}
+      <CompleteMoveCell
+        annotations={variations[0].annotations}
+        comment={variations[0].comment}
+        halfMoves={variations[0].halfMoves}
+        move={variations[0].san}
+        fen={variations[0].fen}
+        movePath={newPath}
+        showComments={showComments}
+        isStart={equal(newPath, start)}
+        first={first}
+        targetRef={targetRef}
+      />
+      <RenderMainline
+        tree={variations[0]}
+        depth={depth}
+        start={start}
+        showComments={showComments}
+        targetRef={targetRef}
+        path={newPath}
+        toggleVariationState={toggleVariationState}
+      />
+    </>
+  );
+}
 
-    const newPath = [...path, 0];
-    return (
-      <>
-        {variations.length > 0 && (
-          <CompleteMoveCell
+function RenderVariations({
+  tree,
+  depth,
+  path,
+  start,
+  first,
+  showComments,
+  renderMoves,
+  nextLevelExpanded,
+  childInPath,
+  targetRef,
+  variationState,
+}: {
+  tree: TreeNode;
+  depth: number;
+  path: number[];
+  start?: number[];
+  first?: boolean;
+  showComments: boolean;
+  renderMoves: boolean;
+  nextLevelExpanded: boolean;
+  childInPath: boolean;
+  targetRef: React.RefObject<HTMLSpanElement>;
+  variationState: VariationState;
+}) {
+  if (!renderMoves) {
+    const variationCells = [];
+    let currentNode = tree;
+    let currentPath = [...path];
+    let parentNode = currentNode;
+
+    if (!currentNode.children?.length) return null;
+
+    variationCells.push(
+      <VariationCell
+        key={currentNode.fen}
+        variation={currentNode}
+        path={currentPath}
+        variationState={variationState}
+        targetRef={targetRef}
+        start={start}
+        showComments={showComments}
+        depth={depth + 1}
+        startsMainline={true}
+        childInPath={childInPath}
+        nextLevelExpanded={nextLevelExpanded}
+      />,
+    );
+
+    let pathIncludesChild = childInPath;
+    while (currentNode.children.length > 0) {
+      parentNode = currentNode;
+      currentNode = currentNode.children[0];
+      if (!pathIncludesChild) {
+        currentPath = [...currentPath, 0];
+      } else {
+        pathIncludesChild = false;
+      }
+
+      if (parentNode.children.length > 1 && currentNode.children.length > 0) {
+        variationCells.push(
+          <VariationCell
+            key={currentNode.fen}
+            variation={currentNode}
+            path={currentPath}
+            variationState={variationState}
             targetRef={targetRef}
-            annotations={variations[0].annotations}
-            comment={variations[0].comment}
-            halfMoves={variations[0].halfMoves}
-            move={variations[0].san}
-            fen={variations[0].fen}
-            movePath={newPath}
-            showComments={showComments}
-            isStart={equal(newPath, start)}
-            first={first}
-          />
-        )}
-
-        <VariationCell moveNodes={variationNodes} />
-
-        {tree.children.length > 0 && (
-          <RenderVariationTree
-            targetRef={targetRef}
-            tree={tree.children[0]}
-            depth={depth + 1}
-            showVariations={showVariations}
             start={start}
             showComments={showComments}
-            path={newPath}
-          />
-        )}
+            depth={depth + 1}
+            startsMainline={false}
+            childInPath={false}
+            nextLevelExpanded={nextLevelExpanded}
+          />,
+        );
+      }
+    }
+
+    return <>{variationCells}</>;
+  }
+
+  const variations = tree.children;
+  if (!variations?.length) return null;
+
+  const newMainlinePath = childInPath ? [...path] : [...path, 0];
+
+  if (variations.length === 1) {
+    return (
+      <>
+        <CompleteMoveCell
+          targetRef={targetRef}
+          annotations={variations[0].annotations}
+          comment={variations[0].comment}
+          halfMoves={variations[0].halfMoves}
+          move={variations[0].san}
+          fen={variations[0].fen}
+          movePath={newMainlinePath}
+          showComments={showComments}
+          isStart={equal(newMainlinePath, start)}
+          first={first}
+        />
+        <RenderVariations
+          tree={variations[0]}
+          depth={depth}
+          start={start}
+          showComments={showComments}
+          targetRef={targetRef}
+          path={newMainlinePath}
+          variationState={variationState}
+          renderMoves={true}
+          childInPath={false}
+          nextLevelExpanded={nextLevelExpanded}
+        />
       </>
     );
-  },
-  (prev, next) => {
-    return (
-      prev.tree === next.tree &&
-      prev.depth === next.depth &&
-      prev.first === next.first &&
-      prev.showVariations === next.showVariations &&
-      prev.showComments === next.showComments &&
-      equal(prev.path, next.path) &&
-      equal(prev.start, next.start)
-    );
-  },
-);
+  }
 
-function VariationCell({ moveNodes }: { moveNodes: React.ReactNode[] }) {
-  const [expanded, setExpanded] = useState(true);
-  if (moveNodes.length === 0) return null;
   return (
-    <Box className={styles.variationBorder}>
-      <ActionIcon size="xs" onClick={() => setExpanded((v) => !v)}>
-        {expanded ? <IconMinus size="0.5rem" /> : <IconPlus size="0.5rem" />}
-      </ActionIcon>
-      {expanded &&
-        moveNodes.map((node, i) => (
-          <Box key={i} className={styles.lineBeforeVariation}>
-            {node}
-          </Box>
-        ))}
+    <>
+      <CompleteMoveCell
+        targetRef={targetRef}
+        annotations={variations[0].annotations}
+        comment={variations[0].comment}
+        halfMoves={variations[0].halfMoves}
+        move={variations[0].san}
+        fen={variations[0].fen}
+        movePath={newMainlinePath}
+        showComments={showComments}
+        isStart={equal(newMainlinePath, start)}
+        first={first}
+      />
+      {variations.slice(1).map((variation, index) => (
+        <RenderVariations
+          key={variation.fen}
+          tree={{ ...variation, children: [variation] }}
+          depth={depth}
+          start={start}
+          showComments={showComments}
+          targetRef={targetRef}
+          path={[...newMainlinePath.slice(0, -1), index + 1]}
+          variationState={variationState}
+          renderMoves={false}
+          childInPath={true}
+          nextLevelExpanded={nextLevelExpanded}
+        />
+      ))}
+    </>
+  );
+}
+
+function VariationCell({
+  variation,
+  path,
+  depth,
+  start,
+  showComments,
+  startsMainline,
+  childInPath,
+  nextLevelExpanded,
+  targetRef,
+  variationState,
+}: {
+  variation: TreeNode;
+  path: number[];
+  variationState: VariationState;
+  targetRef: React.RefObject<HTMLSpanElement>;
+  start?: number[];
+  showComments: boolean;
+  depth: number;
+  startsMainline: boolean;
+  childInPath: boolean;
+  nextLevelExpanded: boolean;
+}) {
+  const store = useContext(TreeStateContext);
+  if (!store) {
+    throw new Error("VariationCell must be used within a TreeStateProvider");
+  }
+  const positionPath = useStore(store, (s) => s.position);
+
+  const currentPath = childInPath ? [...path.slice(0, -1)] : [...path];
+  const childIndex = childInPath ? path[path.length - 1] : 0;
+  const remainingPositionPath = positionPath.slice(currentPath.length);
+
+  const isOnPath = currentPath.every((value, i) => positionPath[i] === value);
+  const isPositionDeeper = positionPath.length > currentPath.length;
+  const isDiverging =
+    remainingPositionPath.length > 0 &&
+    ((remainingPositionPath[0] !== 0 && childIndex === 0) ||
+      (remainingPositionPath[0] === childIndex &&
+        isOnNextDivergenceFromMainline(variation, [
+          0,
+          ...remainingPositionPath.slice(1),
+        ])));
+  const isInCurrentPath = isOnPath && isPositionDeeper && isDiverging;
+
+  const [expanded, setExpanded] = useState(() => isInCurrentPath);
+  const [chevronClicked, setChevronClicked] = useState(false);
+
+  useEffect(() => {
+    if (!expanded && variationState === "variations" && isInCurrentPath) {
+      setExpanded(true);
+    }
+  }, [variationState, expanded, isInCurrentPath]);
+
+  if (depth > 1 && !nextLevelExpanded) {
+    return null;
+  }
+
+  return (
+    <Box className={depth === 1 ? undefined : styles.variationBorder}>
+      {hasMultipleChildrenInChain(variation) ? (
+        expanded ? (
+          isInCurrentPath ? (
+            <span style={{ width: "0.6rem", display: "inline-block" }} />
+          ) : (
+            <IconChevronDown
+              size="0.6rem"
+              style={{
+                opacity: chevronClicked ? 1 : 0,
+                transition: "opacity 0.4s",
+                cursor: "pointer",
+              }}
+              onMouseEnter={(event) => {
+                event.currentTarget.style.opacity = "1";
+              }}
+              onMouseLeave={(event) => {
+                setChevronClicked(false);
+                event.currentTarget.style.opacity = "0";
+              }}
+              onClick={() => setExpanded(false)}
+            />
+          )
+        ) : (
+          <IconChevronRight
+            size="0.6rem"
+            style={{
+              cursor: "pointer",
+            }}
+            onClick={() => {
+              setChevronClicked(true);
+              setExpanded(true);
+            }}
+          />
+        )
+      ) : (
+        <span style={{ width: "0.6rem", display: "inline-block" }} />
+      )}
+      {startsMainline ? (
+        <IconPointFilled size="0.6rem" />
+      ) : (
+        <IconPoint size="0.6rem" />
+      )}
+      <RenderVariations
+        tree={variation}
+        depth={depth}
+        path={path}
+        start={start}
+        showComments={showComments}
+        first={true}
+        renderMoves={true}
+        nextLevelExpanded={expanded}
+        targetRef={targetRef}
+        variationState={variationState}
+        childInPath={childInPath}
+      />
     </Box>
   );
 }
 
-export default memo(GameNotation);
+function RenderRepertoire({
+  tree,
+  depth,
+  path,
+  start,
+  first,
+  showComments,
+  nextLevelExpanded,
+  targetRef,
+  variationState,
+}: {
+  tree: TreeNode;
+  depth: number;
+  start?: number[];
+  path: number[];
+  first?: boolean;
+  showComments: boolean;
+  nextLevelExpanded?: boolean;
+  targetRef: React.RefObject<HTMLSpanElement>;
+  variationState: VariationState;
+}) {
+  const variations = tree.children;
+  if (!variations?.length) return null;
+
+  if (variations.length === 1 && depth > 0) {
+    const newPath = [...path, 0];
+    return (
+      <>
+        <CompleteMoveCell
+          targetRef={targetRef}
+          annotations={variations[0].annotations}
+          comment={variations[0].comment}
+          halfMoves={variations[0].halfMoves}
+          move={variations[0].san}
+          fen={variations[0].fen}
+          movePath={newPath}
+          showComments={showComments}
+          isStart={equal(newPath, start)}
+          first={first}
+        />
+        <RenderRepertoire
+          targetRef={targetRef}
+          tree={variations[0]}
+          depth={depth}
+          start={start}
+          showComments={showComments}
+          path={newPath}
+          variationState={variationState}
+          nextLevelExpanded={nextLevelExpanded}
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      {variations.map((variation, index) => (
+        <RepertoireCell
+          key={variation.fen}
+          variation={variation}
+          path={[...path, index]}
+          targetRef={targetRef}
+          start={start}
+          showComments={showComments}
+          depth={depth + 1}
+          variationState={variationState}
+          nextLevelExpanded={nextLevelExpanded}
+        />
+      ))}
+    </>
+  );
+}
+
+function RepertoireCell({
+  variation,
+  path,
+  depth,
+  start,
+  showComments,
+  nextLevelExpanded,
+  targetRef,
+  variationState,
+}: {
+  variation: TreeNode;
+  path: number[];
+  variationState: VariationState;
+  targetRef: React.RefObject<HTMLSpanElement>;
+  start?: number[];
+  showComments: boolean;
+  depth: number;
+  nextLevelExpanded?: boolean;
+}) {
+  const store = useContext(TreeStateContext);
+  if (!store) {
+    throw new Error("RepertoireCell must be used within a TreeStateProvider");
+  }
+  const position = useStore(store, (s) => s.position);
+
+  const isOnPath = path.every((value, i) => position[i] === value);
+  const isPositionDeeper = position.length > path.length;
+  const remainingPath = position.slice(path.length);
+  const isInCurrentPath =
+    isPositionDeeper &&
+    isOnPath &&
+    hasMultipleChildrenUntilPosition(variation, remainingPath);
+
+  const [expanded, setExpanded] = useState(() => isInCurrentPath);
+  const [chevronClicked, setChevronClicked] = useState(false);
+
+  useEffect(() => {
+    if (!expanded && variationState === "repertoire" && isInCurrentPath) {
+      setExpanded(true);
+    }
+  }, [variationState, expanded, isInCurrentPath]);
+
+  if (depth > 1 && !nextLevelExpanded) {
+    return null;
+  }
+
+  return (
+    <Box className={depth === 1 ? undefined : styles.variationBorder}>
+      {hasMultipleChildrenInChain(variation) ? (
+        expanded ? (
+          isInCurrentPath ? (
+            <span style={{ width: "0.6rem", display: "inline-block" }} />
+          ) : (
+            <IconChevronDown
+              size="0.6rem"
+              style={{
+                opacity: chevronClicked ? 1 : 0,
+                transition: "opacity 0.4s",
+                cursor: "pointer",
+              }}
+              onMouseEnter={(event) => {
+                event.currentTarget.style.opacity = "1";
+              }}
+              onMouseLeave={(event) => {
+                setChevronClicked(false);
+                event.currentTarget.style.opacity = "0";
+              }}
+              onClick={() => setExpanded(false)}
+            />
+          )
+        ) : (
+          <IconChevronRight
+            size="0.6rem"
+            style={{
+              cursor: "pointer",
+            }}
+            onClick={() => {
+              setChevronClicked(true);
+              setExpanded(true);
+            }}
+          />
+        )
+      ) : (
+        <span style={{ width: "0.6rem", display: "inline-block" }} />
+      )}
+      <IconPointFilled size="0.6rem" />
+      <CompleteMoveCell
+        annotations={variation.annotations}
+        comment={variation.comment}
+        halfMoves={variation.halfMoves}
+        move={variation.san}
+        fen={variation.fen}
+        movePath={path}
+        showComments={showComments}
+        isStart={equal(path, start)}
+        first={true}
+        targetRef={targetRef}
+      />
+      <RenderRepertoire
+        tree={variation}
+        depth={depth}
+        path={path}
+        start={start}
+        showComments={showComments}
+        nextLevelExpanded={expanded}
+        targetRef={targetRef}
+        variationState={variationState}
+      />
+    </Box>
+  );
+}
+
+export default GameNotation;


### PR DESCRIPTION
The provided changes aim to improve the readability, usability, and functionality of the game notation features, providing a more intuitive and interactive experience for users.

- Improved the mainline view to display a symbol when the current position is a sideline, enhancing clarity for users navigating through variations.
![En_Croissant_Main_Line_View](https://github.com/user-attachments/assets/805ff03f-58fe-4c05-a9b1-ab033dd978c2)
- Enhanced the visual appearance of the variations view for a consistent and compact display, making it easier to follow different branches.
![En_Croissant_Variations_View](https://github.com/user-attachments/assets/d32d0ab7-10da-4154-89db-47febe817a87)
- Implemented a completely new repertoire view, particularly useful for displaying variations in a chess opening repertoire, providing a structured and clear presentation of opening lines.
![En_Croissant_Repertoire_View](https://github.com/user-attachments/assets/72c6e2de-0d73-4016-b98d-96dadaf581f5)
- Added folding functionality in both variations and repertoire views, allowing users to expand or collapse sections for a more organized and manageable display.
- Enhanced the rendering of comments with Markdown support, including handling of multiple lines and external links, to improve readability and functionality.