### PR TITLE
Restore window size on startup by not overriding it with maximized: true

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -68,7 +68,6 @@
     "windows": [
       {
         "title": "En Croissant",
-        "maximized": true,
         "visible": false,
         "decorations": true
       }


### PR DESCRIPTION
For me (on linux) the main application window of en-croissant was always starting maximized, and not being remembered. The window_state plugin is already loaded, and *should* handle this, but it turns out the `"maximized": true` setting of `tauri.conf.json` was taking precedence.

This PR removes that line from the json, allowing window_state to correctly work on my system.