### PR TITLE
dockerfile for en-croissant app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Use Node.js base image
+FROM node:18
+
+# Install required system dependencies
+RUN apt-get update && \
+    apt-get install -y build-essential autoconf automake libtool pkg-config \
+    libgtk-3-dev libjavascriptcoregtk-4.1-dev libwebkit2gtk-4.1-dev && \
+    pkg-config --cflags --libs libsoup-3.0 && \
+    export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig/libsoup-3.0.pc
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+    . "$HOME/.cargo/env" add x86_64-unknown-linux-gnu
+
+# Install pnpm
+RUN npm install -g pnpm
+
+# Clone the app and set the working directory
+RUN git clone https://github.com/franciscoBSalgueiro/en-croissant /en-croissant
+
+# Set working directory to the cloned repository
+WORKDIR /en-croissant
+
+# Install dependencies inside the cloned repository
+RUN pnpm install
+
+# Build the app (make sure cargo is available)
+RUN . $HOME/.cargo/env && pnpm build
+
+# Copy built app to /output
+RUN mkdir -p /output && \
+    cp -r /en-croissant/src-tauri/target/release/en-croissant /output
+


### PR DESCRIPTION
# Add Dockerfile for Building En-Croissant in a Reproducible Environment

### Description
This PR introduces a Dockerfile that automates the process of building the En-Croissant application in a containerized environment. This ensures a clean, isolated environment for the application, making it easier for others to reproduce the setup.

### Motivation
I needed an app to analyze my chess games, and this project fit perfectly. Since I’m not a developer and didn’t want to install additional software on my system, I opted for Docker. This way, I can use the app without installing anything extra, and I thought others could benefit from this easy setup as well.

### What this does
- Uses `node:18` as a base image
- Installs Rust and GTK-related libraries
- Clones the En-Croissant repo and installs dependencies using `pnpm`
- Builds the app and outputs the binary to `/output` inside the container

### Usage
```
docker build -t en-croissant .
docker run -d --name en-croissant-container en-croissant
docker cp en-croissant-container:/output .
./output/en-croissant
```