### PR TITLE
Fixing crash on multiple View Solution in Puzzles

### DIFF
--- a/src/components/puzzles/Puzzles.tsx
+++ b/src/components/puzzles/Puzzles.tsx
@@ -50,7 +50,6 @@ import MoveControls from "../common/MoveControls";
 import { TreeStateContext } from "../common/TreeStateContext";
 import AddPuzzle from "./AddPuzzle";
 import PuzzleBoard from "./PuzzleBoard";
-import { set } from "zod";
 
 function Puzzles({ id }: { id: string }) {
   const { t } = useTranslation();


### PR DESCRIPTION
Disabling the 'View Solution' button after the click and reenabling
after solution is shown
Fixing https://github.com/franciscoBSalgueiro/en-croissant/issues/554