### PR TITLE
fix: stop text from being selectable when unnecessary

### DIFF
--- a/src/styles/global.css.ts
+++ b/src/styles/global.css.ts
@@ -46,3 +46,8 @@ globalStyle("cg-board square.oc.move-dest:hover", {
   },
   borderRadius: 0,
 });
+
+globalStyle("*", {
+  userSelect: "none",
+  WebkitUserSelect: "none",
+});


### PR DESCRIPTION
Stops text from being selectable