### PR TITLE
fix: change coords to lowercase to match chess notation

### DIFF
--- a/src/styles/chessgroundBaseOverride.css
+++ b/src/styles/chessgroundBaseOverride.css
@@ -155,7 +155,6 @@ piece.fading {
   flex-flow: row;
   width: 100%;
   height: 1rem;
-  text-transform: uppercase;
   text-align: center;
 }
 


### PR DESCRIPTION
Changes the board coordinates to lowercase to match algebraic chess notation.