### PR TITLE
Focus annotation tab

### DIFF
--- a/src/components/boards/BoardAnalysis.tsx
+++ b/src/components/boards/BoardAnalysis.tsx
@@ -108,9 +108,13 @@ function BoardAnalysis() {
     ],
     [keyMap.ANALYSIS_TAB.keys, () => setCurrentTabSelected("analysis")],
     [keyMap.DATABASE_TAB.keys, () => setCurrentTabSelected("database")],
-    [keyMap.ANNOTATE_TAB.keys, () => {
-      setCurrentTabSelected("annotate"); triggerAnnotationFocus()
-    }],
+    [
+      keyMap.ANNOTATE_TAB.keys,
+      () => {
+        setCurrentTabSelected("annotate");
+        triggerAnnotationFocus();
+      },
+    ],
     [keyMap.INFO_TAB.keys, () => setCurrentTabSelected("info")],
     [
       keyMap.TOGGLE_ALL_ENGINES.keys,

--- a/src/components/panels/annotation/AnnotationPanel.tsx
+++ b/src/components/panels/annotation/AnnotationPanel.tsx
@@ -1,4 +1,5 @@
 import { TreeStateContext } from "@/components/common/TreeStateContext";
+import { annotationFocusAtom } from "@/state/atoms";
 import {
   ANNOTATION_INFO,
   type Annotation,
@@ -22,7 +23,6 @@ import { memo, useContext, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import AnnotationEditor from "./AnnotationEditor";
-import { annotationFocusAtom } from "@/state/atoms";
 
 const SymbolButton = memo(function SymbolButton({
   curAnnotations,
@@ -83,7 +83,7 @@ function AnnotationPanel() {
 
   useEffect(() => {
     editorRef.current?.focus();
-  }, [focusSignal])
+  }, [focusSignal]);
 
   return (
     <Stack h="100%" gap={0}>

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -286,10 +286,9 @@ export const currentInvisibleAtom = tabValue(invisibleFamily);
 const tabFamily = atomFamily((tab: string) => atom("info"));
 export const currentTabSelectedAtom = tabValue(tabFamily);
 export const annotationFocusAtom = atom(0);
-export const triggerAnnotationFocusAtom = atom(
-  null,
-  (_, set) => { set(annotationFocusAtom, n => n + 1) }
-)
+export const triggerAnnotationFocusAtom = atom(null, (_, set) => {
+  set(annotationFocusAtom, (n) => n + 1);
+});
 
 const localOptionsFamily = atomFamily((tab: string) =>
   atom<LocalOptions>({


### PR DESCRIPTION
This pull request improves when focus is set on the annotation editor text area. If you click on the annotation tab, or if you use the annotation tab shortcut key, the focus automatically shifts to the text area. 

Regarding implementation: `useEditor` does not immediately return an editor, it starts out as `null`. So I set a timeout of 50ms before calling `focus`. A little ugly, but I couldn't find a reliable way to call it as soon as the editor exists. I don't have much React experience so if there's a better way please let me know!

When following the contribution guidelines I noticed a couple of things:
- It asks to run `pnpm tauri build -b none`. For me that only gave errors and I just ran `pnpm  build`. Is that correct?
- It asks to lint with `pnpm format`  and `pnpm lint:fix`. When I did that I got changes in more than 200 files. I tried to only format the files I changed but it seems that `pnpm format` will always run on the whole repository.