### PR TITLE
Put single line comments inline

### DIFF
--- a/src/components/common/Comment.tsx
+++ b/src/components/common/Comment.tsx
@@ -13,7 +13,7 @@ export function Comment({ comment }: { comment: string }) {
       pl={0}
       mx={4}
       style={{
-        display: multipleLine ? "block" : "inline-block",
+        display: multipleLine ? "block" : "inline",
       }}
     >
       <Markdown
@@ -21,6 +21,8 @@ export function Comment({ comment }: { comment: string }) {
           a: ({ node, ...props }) => (
             <a {...props} target="_blank" rel="noreferrer" />
           ),
+          p: ({ node, ...props }) =>
+            multipleLine ? <p {...props} /> : <span {...props} />,
         }}
         rehypePlugins={[rehypeRaw, remarkGfm]}
       >


### PR DESCRIPTION
This PR puts single line comments in the game annotation inline whenever possible. This deals with one of the suggestions in #445.

### Implementation
All comment text blocks are inside a `Markdown` component. That component puts text in `<p>` tags inside the eventual HTML. I had to change it so that text ends up in `<span>` tags, otherwise setting CSS `display: inline` would have no effect.

### Before
<img width="451" height="454" alt="screenshot_before" src="https://github.com/user-attachments/assets/604bec5a-b8eb-4c6b-8736-af8cdea66abb" />

### After
<img width="454" height="457" alt="screenshot_after" src="https://github.com/user-attachments/assets/d3063480-de41-4447-af52-dfc6563061ce" />

### Multiline Comments
I have left multiline comments as blocks starting on a newline since it seems difficult to guess how a multiline comment should line wrap.

<img width="237" height="180" alt="screenshot_multiline" src="https://github.com/user-attachments/assets/f8652e60-c09a-42c5-ac59-f30c1c3d1baf" />
