### PR TITLE
Fix move number bug

### DIFF
--- a/src/components/common/GameNotation.tsx
+++ b/src/components/common/GameNotation.tsx
@@ -218,7 +218,6 @@ const RenderVariationTree = memo(
                 targetRef={targetRef}
                 tree={variation}
                 depth={depth + 2}
-                first
                 showVariations={showVariations}
                 showComments={showComments}
                 start={start}


### PR DESCRIPTION
This PR fixes a bug in the game notation where the move number would be shown in the second move of a variation, even if that move was a black move.

### Before
<img width="99" height="82" alt="before" src="https://github.com/user-attachments/assets/1fd7e5d1-3228-46a6-b8a7-4f9e22b5dd1e" />

### After
<img width="74" height="73" alt="after" src="https://github.com/user-attachments/assets/5f0f71e3-a9aa-46ef-8c88-9dda9ec2f294" />
