### PR TITLE
Show tablebase for op1 positions

### DIFF
--- a/src/components/panels/analysis/AnalysisPanel.tsx
+++ b/src/components/panels/analysis/AnalysisPanel.tsx
@@ -9,7 +9,12 @@ import {
   enginesAtom,
 } from "@/state/atoms";
 import { getVariationLine } from "@/utils/chess";
-import { getPiecesCount, hasCaptures, positionFromFen } from "@/utils/chessops";
+import {
+  getPiecesCount,
+  hasCaptures,
+  isOp1,
+  positionFromFen,
+} from "@/utils/chessops";
 import type { Engine } from "@/utils/engines";
 import { getInitials } from "@/utils/format";
 import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd";
@@ -119,7 +124,8 @@ function AnalysisPanel() {
           >
             {pos &&
               (getPiecesCount(pos) <= 7 ||
-                (getPiecesCount(pos) === 8 && hasCaptures(pos))) && (
+                (getPiecesCount(pos) === 8 &&
+                  (hasCaptures(pos) || isOp1(pos)))) && (
                 <>
                   <TablebaseInfo fen={currentNodeFen} turn={pos.turn} />
                   <Space h="sm" />

--- a/src/utils/chessops.ts
+++ b/src/utils/chessops.ts
@@ -130,6 +130,26 @@ export function hasCaptures(pos: Chess) {
   return false;
 }
 
+export function isOp1(pos: Chess) {
+  const whitePawns = pos.board.pawn.intersect(pos.board.white);
+  const blackPawns = pos.board.pawn.intersect(pos.board.black);
+
+  // Exclude positions where one side has only a king and at most one pawn
+  const whiteSize = pos.board.white.size();
+  const blackSize = pos.board.black.size();
+  if (whiteSize <= 2 && whitePawns.size() === whiteSize - 1) return false;
+  if (blackSize <= 2 && blackPawns.size() === blackSize - 1) return false;
+
+  // Check for at least one opposing pair of pawns
+  let shifted = whitePawns.shl64(8);
+  let squaresInFront = shifted;
+  for (let i = 0; i < 4 && shifted.nonEmpty(); i++) {
+    shifted = shifted.shl64(8);
+    squaresInFront = squaresInFront.union(shifted);
+  }
+  return squaresInFront.intersects(blackPawns);
+}
+
 export function parseSanOrUci(pos: Chess, sanOrUci: string): Move | null {
   const sanParsed = parseSan(pos, sanOrUci);
   if (sanParsed) {


### PR DESCRIPTION
Adds a check so the tablebase info gets shown for positions in the [Op1 tablebase](https://lichess.org/@/Lichess/blog/op1-partial-8-piece-tablebase-available/1ptPBDpC)