### PR TITLE
fix: cap download progress at 100% when local count exceeds server total

### DIFF
--- a/src/components/home/AccountCard.tsx
+++ b/src/components/home/AccountCard.tsx
@@ -146,8 +146,11 @@ export function AccountCard({
 
   const downloadedGames =
     database?.type === "success" ? database.game_count : 0;
+  const effectiveTotal = Math.max(total, downloadedGames);
   const percentage =
-    total === 0 ? "0.00" : ((downloadedGames / total) * 100).toFixed(2);
+    effectiveTotal === 0
+      ? "0.00"
+      : ((downloadedGames / effectiveTotal) * 100).toFixed(2);
 
   async function getLastGameDate({ database }: { database: DatabaseInfo }) {
     const games = await query_games(database.file, {
@@ -254,11 +257,11 @@ export function AccountCard({
               {t("Common.Games")}
             </Text>
             <Text size="xs" fw={500}>
-              {downloadedGames} / {total}
+              {downloadedGames} / {effectiveTotal}
             </Text>
           </Group>
           <Progress
-            value={loading ? 100 : (downloadedGames / total) * 100}
+            value={loading ? 100 : (downloadedGames / effectiveTotal) * 100}
             size="sm"
             striped={loading}
             animated={loading}


### PR DESCRIPTION
## Problem

The download progress bar and game counter (e.g. `1050 / 1000`) could display values over 100%. This affected both Lichess and Chess.com accounts.

The root cause is a mismatch between the server-reported total and the actual number of games downloaded:

- **Lichess**: `totalGames` is computed by summing `perfs.*.games` for each time control (ultraBullet, bullet, blitz, rapid, classical, correspondence). These counts can include unrated games, but the download endpoint only fetches rated games — meaning the downloaded count can actually exceed the server total in some edge cases (e.g. correspondence games previously not counted, off-by-one in the API response).
- **Chess.com**: `totalGames` is computed from `win + loss + draw` in the stats endpoint, but the archives endpoint can return game types not reflected in those stats records.

Closes #84, #97, #203, #242, #286.

## Solution

Introduce `effectiveTotal = Math.max(total, downloadedGames)` in `AccountCard.tsx`. If the locally downloaded count ever exceeds the server-reported total, the effective total adjusts upward to match — so the displayed `X / Y` ratio and progress bar value are capped at 100%.

| Scenario | Before | After |
|---|---|---|
| 1050 downloaded, server says 1000 | `1050 / 1000 (105%)` | `1050 / 1050 (100%)` |
| 950 downloaded, server says 1000 | `950 / 1000 (95%)` | `950 / 1000 (95%)` _(unchanged)_ |
| 0 downloaded, server says 0 | `0.00%` | `0.00%` _(unchanged)_ |

The download logic itself (`total - downloadedGames` used as a size estimate for the in-flight progress bar) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)