### PR TITLE
Fix castling via text Move Input

### DIFF
--- a/src/utils/chess.ts
+++ b/src/utils/chess.ts
@@ -330,14 +330,11 @@ export function getPGN(
 
 export function parseKeyboardMove(san: string, fen: string) {
   function cleanSan(san: string) {
-    if (san.length > 2) {
-      const cleanedSan = san
-        .replace(/^([kqbnr])/i, (_, match) => match.toUpperCase())
-        .replace("o-o-o", "O-O-O")
-        .replace("o-o", "O-O");
-      return cleanedSan;
-    }
-    return san;
+    // Normalize castling: O, o, or 0 with optional hyphens
+    if (/^[oO0]-?[oO0]-?[oO0]$/.test(san)) return "O-O-O";
+    if (/^[oO0]-?[oO0]$/.test(san)) return "O-O";
+    // Uppercase piece letters for non-castling moves
+    return san.replace(/^([kqbnr])/i, (_, match) => match.toUpperCase());
   }
 
   const [pos] = positionFromFen(fen);


### PR DESCRIPTION
## Summary

Fixes #316.

- The `cleanSan()` function in `parseKeyboardMove()` had a `length > 2` guard that blocked 2-character inputs like `OO` and `00` from being recognized as kingside castling
- Literal string matching (`"o-o"`, `"o-o-o"`) only caught exact lowercase hyphenated forms, missing `O-O`, `0-0`, `OO`, `00`, etc.
- Replaced with regex-based normalization that accepts any combination of `O`/`o`/`0` with optional hyphens for both kingside and queenside castling

## Test plan

- [ ] Enable "text Move Input" setting
- [ ] Start a game against the engine
- [ ] Reach a castling position and verify all common notations work: `O-O`, `o-o`, `0-0`, `OO`, `oo`, `00` (kingside) and `O-O-O`, `o-o-o`, `0-0-0`, `OOO`, `ooo`, `000` (queenside)

🤖 Generated with [Claude Code](https://claude.com/claude-code)