### PR TITLE
Fix engine settings lost when switching tabs in unlimited mode

### DIFF
--- a/src/components/boards/BoardGame.tsx
+++ b/src/components/boards/BoardGame.tsx
@@ -256,7 +256,7 @@ function BoardGame() {
       type: "engine",
       name: settings.engine?.name ?? "Engine",
       path: settings.engine?.path ?? "",
-      options: (settings.engine?.settings ?? [])
+      options: (settings.engineSettings ?? settings.engine?.settings ?? [])
         .filter((s) => s.name !== "MultiPV")
         .map((s) => ({
           name: s.name,

--- a/src/components/boards/OpponentForm.tsx
+++ b/src/components/boards/OpponentForm.tsx
@@ -13,7 +13,7 @@ import type { GoMode } from "@/bindings";
 import TimeInput, { type TimeType } from "@/components/common/TimeInput";
 import EngineSettingsForm from "@/components/panels/analysis/EngineSettingsForm";
 import type { TimeControlField } from "@/utils/clock";
-import type { LocalEngine } from "@/utils/engines";
+import type { EngineSettings, LocalEngine } from "@/utils/engines";
 import { EnginesSelect } from "./EnginesSelect";
 
 export type OpponentSettings =
@@ -29,6 +29,7 @@ export type OpponentSettings =
       timeControl?: TimeControlField;
       engine: LocalEngine | null;
       go: GoMode;
+      engineSettings?: EngineSettings;
       timeUnit?: TimeType;
       incrementUnit?: TimeType;
     };
@@ -63,10 +64,7 @@ export function OpponentForm({
         ...prev,
         type: "engine",
         engine: null,
-        go: {
-          t: "Depth",
-          c: 24,
-        },
+        go: ("go" in prev && prev.go) || { t: "Depth", c: 24 },
       }));
     }
   }
@@ -110,7 +108,13 @@ export function OpponentForm({
       {opponent.type === "engine" && (
         <EnginesSelect
           engine={opponent.engine}
-          setEngine={(engine) => setOpponent((prev) => ({ ...prev, engine }))}
+          setEngine={(engine) =>
+            setOpponent((prev) => ({
+              ...prev,
+              engine,
+              engineSettings: engine?.settings || undefined,
+            }))
+          }
         />
       )}
 
@@ -212,7 +216,8 @@ export function OpponentForm({
               gameMode
               settings={{
                 go: opponent.go,
-                settings: opponent.engine.settings || [],
+                settings:
+                  opponent.engineSettings || opponent.engine.settings || [],
                 enabled: true,
                 synced: false,
               }}
@@ -223,11 +228,16 @@ export function OpponentForm({
                   }
                   const newSettings = fn({
                     go: prev.go,
-                    settings: prev.engine?.settings || [],
+                    settings:
+                      prev.engineSettings || prev.engine?.settings || [],
                     enabled: true,
                     synced: false,
                   });
-                  return { ...prev, ...newSettings };
+                  return {
+                    ...prev,
+                    go: newSettings.go,
+                    engineSettings: newSettings.settings,
+                  };
                 })
               }
               minimal={true}


### PR DESCRIPTION
## Summary

Fixes #670.

The previous approach (using `useRef` in `GoModeInput` to remember values) was wrong — it addressed the wrong layer entirely. The real problems were:

**1. Engine settings (Threads/Hash) were never persisted per-opponent.** `OpponentForm` always read from `opponent.engine.settings` (the engine's global defaults), but updates from `EngineSettingsForm` were spread into an orphaned `settings` key on the opponent object that nobody ever read back. Every re-render discarded the changes.

**Fix:** Added an `engineSettings` field to `OpponentSettings` to store per-opponent overrides. Both `OpponentForm` (for reading/writing) and `BoardGame.toPlayerConfig()` (for sending to the engine) now use this field, falling back to the engine defaults when no override exists.

**2. GoMode was reset when switching Human→Engine.** `updateType("engine")` always hardcoded `go: { t: "Depth", c: 24 }`, discarding any previously set value.

**Fix:** Preserve the existing `go` value when switching back to engine mode.

## Test plan

- [ ] Play Chess → select an engine → set Time Settings to Unlimited
- [ ] Change Depth to 30, switch to Human, switch back to Engine → verify Depth is still 30
- [ ] Change Threads to 4, switch to Time mode, switch back to Unlimited → verify Threads is still 4
- [ ] Change Hash, switch tabs, switch back → verify Hash is preserved
- [ ] Select a different engine → verify settings reset to that engine's defaults
- [ ] Start a game and verify the correct Threads/Hash values are sent to the engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)