### PR TITLE
Order games from position search by ELO descending

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -611,6 +611,8 @@ pub fn generate_search_index(
         i32,
         i32,
         i32,
+        Option<i32>,
+        Option<i32>,
     )> = games::table
         .select((
             games::id,
@@ -623,6 +625,8 @@ pub fn generate_search_index(
             games::pawn_home,
             games::white_material,
             games::black_material,
+            games::white_elo,
+            games::black_elo,
         ))
         .load(db)?;
 
@@ -638,6 +642,8 @@ pub fn generate_search_index(
         pawn_home,
         white_material,
         black_material,
+        white_elo,
+        black_elo,
     ) in games
     {
         let entry = SearchGameEntry::from_game_data(
@@ -651,6 +657,8 @@ pub fn generate_search_index(
             pawn_home,
             white_material,
             black_material,
+            white_elo,
+            black_elo,
         );
         writer.push(entry);
     }

--- a/src-tauri/src/db/search_index.rs
+++ b/src-tauri/src/db/search_index.rs
@@ -10,7 +10,7 @@ use rayon::prelude::*;
 use rkyv::{Archive, Deserialize, Serialize};
 
 const MAGIC: &[u8; 4] = b"ECSI";
-const VERSION: u32 = 3;
+const VERSION: u32 = 4;
 const HEADER_SIZE: usize = 8;
 
 fn verify_header(header: &[u8]) -> io::Result<()> {
@@ -83,6 +83,8 @@ pub struct SearchGameEntry {
     pub pawn_home: u16,
     pub white_material: u8,
     pub black_material: u8,
+    pub white_elo: i16,
+    pub black_elo: i16,
     pub fen: Option<String>,
     pub moves: Vec<u8>,
 }
@@ -146,6 +148,8 @@ pub struct SearchGameEntryRef<'a> {
     pub pawn_home: u16,
     pub white_material: u8,
     pub black_material: u8,
+    pub white_elo: i16,
+    pub black_elo: i16,
     pub fen: Option<&'a str>,
     pub moves: &'a [u8],
 }
@@ -167,6 +171,8 @@ impl<'a> From<&'a ArchivedSearchGameEntry> for SearchGameEntryRef<'a> {
             pawn_home: archived.pawn_home.into(),
             white_material: archived.white_material,
             black_material: archived.black_material,
+            white_elo: archived.white_elo.into(),
+            black_elo: archived.black_elo.into(),
             fen: archived.fen.as_ref().map(|s| s.as_str()),
             moves: &archived.moves,
         }
@@ -185,6 +191,8 @@ impl SearchGameEntry {
         pawn_home: i32,
         white_material: i32,
         black_material: i32,
+        white_elo: Option<i32>,
+        black_elo: Option<i32>,
     ) -> Self {
         Self {
             id,
@@ -195,6 +203,8 @@ impl SearchGameEntry {
             pawn_home: pawn_home as u16,
             white_material: white_material as u8,
             black_material: black_material as u8,
+            white_elo: white_elo.unwrap_or(0) as i16,
+            black_elo: black_elo.unwrap_or(0) as i16,
             fen,
             moves,
         }
@@ -323,6 +333,8 @@ mod tests {
                 pawn_home: 0xFFFF,
                 white_material: 39,
                 black_material: 39,
+                white_elo: 2700,
+                black_elo: 2650,
                 fen: None,
                 moves: vec![12, 12, 9, 9], // e4 e5 Nf3 Nc6
             },
@@ -335,6 +347,8 @@ mod tests {
                 pawn_home: 0xF0F0,
                 white_material: 30,
                 black_material: 28,
+                white_elo: 0,
+                black_elo: 2400,
                 fen: Some(
                     "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2".to_string(),
                 ),
@@ -414,6 +428,8 @@ mod tests {
                 pawn_home: 0xFFFF,
                 white_material: 39,
                 black_material: 39,
+                white_elo: 2000 + (i % 800) as i16,
+                black_elo: 1900 + (i % 700) as i16,
                 fen: if i % 3 == 0 {
                     Some("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1".to_string())
                 } else {
@@ -451,6 +467,8 @@ mod tests {
                 pawn_home: 0,
                 white_material: 0,
                 black_material: 0,
+                white_elo: 0,
+                black_elo: 0,
                 fen: None,
                 moves: vec![],
             });


### PR DESCRIPTION
## Summary

Fixes #673.

The `search_position` function's parallel mmap scan collected the first 10 matching games it encountered, which were essentially random. This PR makes two changes to properly surface the highest-rated games:

1. **Add ELO to the search index** — `white_elo` and `black_elo` fields are added to `SearchGameEntry` (stored as `i16`, 0 for unknown). The index version is bumped from 3→4 so old `.ecsi` files are automatically regenerated.

2. **Use a bounded min-heap during the scan** — Instead of storing the first 10 game IDs, a `Mutex<BinaryHeap<Reverse<(i16, i32)>>>` of capacity 10 tracks the top-rated games. Each matching game's `max(white_elo, black_elo)` is compared against the heap minimum, evicting lower-rated entries as higher-rated ones are found.

The move statistics (win/draw/loss per move) are unchanged — they were always computed across all games.

### Files changed

- `search_index.rs` — Add ELO fields to structs, bump version to 4, update `from_game_data()`
- `mod.rs` — Select `white_elo`/`black_elo` in `generate_search_index()`
- `search.rs` — Replace `AtomicI32` array with bounded min-heap, add `ORDER BY` to final DB query

## Test plan

- [x] Open a database (e.g., Lumbra Gigabase)
- [x] Search games from a common position (e.g., after 1. e4 e5 2. Nc3 Nf6)
- [x] Verify the resulting games list shows the highest-rated players (GMs, 2600+)
- [x] Verify move statistics are unchanged
- [x] Verify old search indexes are regenerated automatically on first search

🤖 Generated with [Claude Code](https://claude.com/claude-code)