### PR TITLE
Fix practice mode arrow navigation and sound leaks

### DIFF
--- a/src/components/boards/BoardAnalysis.tsx
+++ b/src/components/boards/BoardAnalysis.tsx
@@ -101,6 +101,13 @@ function BoardAnalysis() {
   const practiceState = useAtomValue(practiceStateAtom);
   const isPracticeRating = practicing && practiceState.phase === "correct";
 
+  const setPracticePath = useStore(store, (s) => s.setPracticePath);
+  useEffect(() => {
+    if (!practicing) {
+      setPracticePath(null);
+    }
+  }, [practicing, setPracticePath]);
+
   useHotkeys([
     [keyMap.SAVE_FILE.keys, () => saveFile()],
     [keyMap.CLEAR_SHAPES.keys, () => clearShapes()],

--- a/src/components/panels/practice/PracticePanel.tsx
+++ b/src/components/panels/practice/PracticePanel.tsx
@@ -64,6 +64,7 @@ function PracticePanel() {
   const root = useStore(store, (s) => s.root);
   const headers = useStore(store, (s) => s.headers);
   const goToMove = useStore(store, (s) => s.goToMove);
+  const setPracticePath = useStore(store, (s) => s.setPracticePath);
   const currentFen = useStore(store, (s) => s.currentNode().fen);
 
   const currentTab = useAtomValue(currentTabAtom);
@@ -125,9 +126,12 @@ function PracticePanel() {
     const c = getCardForReview(deck.positions);
     if (!c) {
       setPracticeState({ phase: "idle" });
+      setPracticePath(null);
       return;
     }
-    goToMove(findFen(c.fen, root));
+    const path = findFen(c.fen, root);
+    goToMove(path);
+    setPracticePath(path);
     setInvisible(true);
     setCardStartTime(Date.now());
     setPracticeState({ phase: "waiting", currentFen: c.fen });
@@ -135,6 +139,7 @@ function PracticePanel() {
     deck.positions,
     root,
     goToMove,
+    setPracticePath,
     setInvisible,
     setCardStartTime,
     setPracticeState,
@@ -545,6 +550,7 @@ function PracticePanel() {
           );
           setDeck({ positions: cards, logs: [] });
           setPracticeState({ phase: "idle" });
+          setPracticePath(null);
           setSessionStats({
             correct: 0,
             incorrect: 0,


### PR DESCRIPTION
## Summary

Fixes #633. Alternative approach to #632.

Two bugs in practice mode:

1. **Wrong variation on right arrow**: `goToNext()` always followed child index 0 (main line), so pressing right arrow after navigating back could land on neighboring variations instead of the drill line the user was working on.

2. **Sound leaks**: `goToNext()` played move/capture sounds unconditionally, even at the practice position where forward navigation should be blocked until the answer is revealed.

### Approach

Added a `practicePath` field to the tree store:
- When a practice drill starts, `PracticePanel` stores the path (array of child indices) to the drill position
- `goToNext()` follows the stored path instead of always taking child 0
- At the end of the path (the practice position), `goToNext()` returns silently — no sound, no position change
- The path is cleared when practice ends, resets, or the user switches away from the practice tab

### Files changed
- `src/state/store/tree.ts` — `practicePath` state + `goToNext` logic
- `src/components/panels/practice/PracticePanel.tsx` — set/clear practice path
- `src/components/boards/BoardAnalysis.tsx` — clear path when leaving practice mode

## Test plan

- [ ] Enter practice mode with saved cards
- [ ] Press left arrow several times to go to the start
- [ ] Press right arrow repeatedly — should follow the drill line exactly, not jump to other variations
- [ ] At the practice position, press right arrow — should do nothing (no sound, no position change)
- [ ] Press "See Answer" or make a move — normal practice flow should resume
- [ ] Switch to a different tab (analysis, database) — arrow navigation should return to normal behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)