### PR TITLE
Fix compilation warnings

### DIFF
--- a/src-tauri/src/db/encoding.rs
+++ b/src-tauri/src/db/encoding.rs
@@ -343,6 +343,7 @@ pub fn decode_game_to_movetext(moves_bytes: &[u8], initial_fen: Fen) -> Result<S
     Ok(render_nodes(&decoded.nodes, &mut state))
 }
 
+#[allow(dead_code)]
 pub fn decode_moves(moves_bytes: Vec<u8>, initial_fen: Fen) -> Result<Vec<String>, Error> {
     let mut chess = Chess::from_setup(initial_fen.into(), CastlingMode::Chess960)
         .or_else(PositionError::ignore_too_much_material)

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -33,7 +33,9 @@ pub struct NewPlayer<'a> {
     pub elo: Option<i32>,
 }
 
+#[allow(dead_code)]
 struct White(pub Player);
+#[allow(dead_code)]
 struct Black(pub Player);
 
 #[derive(Default, Queryable, Serialize, Deserialize, Identifiable, Associations)]

--- a/src-tauri/src/db/search_index.rs
+++ b/src-tauri/src/db/search_index.rs
@@ -203,6 +203,7 @@ impl SearchGameEntry {
 
 #[derive(Clone)]
 pub struct MmapSearchIndex {
+    #[allow(dead_code)] // mmap must be kept alive to back the archived reference
     mmap: Arc<Mmap>,
     archived: &'static ArchivedSearchIndex,
 }
@@ -233,15 +234,18 @@ impl MmapSearchIndex {
     }
 
     #[inline]
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.archived.entries.is_empty()
     }
 
     #[inline]
+    #[allow(dead_code)]
     pub fn get_entry_ref(&self, index: usize) -> Option<SearchGameEntryRef<'_>> {
         self.archived.entries.get(index).map(SearchGameEntryRef::from)
     }
 
+    #[allow(dead_code)]
     pub fn iter(&self) -> impl Iterator<Item = SearchGameEntryRef<'_>> + ExactSizeIterator {
         self.archived.entries.iter().map(SearchGameEntryRef::from)
     }
@@ -272,6 +276,7 @@ impl MmapSearchIndex {
         verify_header(&header).is_ok()
     }
 
+    #[allow(dead_code)]
     pub fn is_up_to_date<P: AsRef<Path>>(db_path: P) -> bool {
         let db_path = db_path.as_ref();
         let index_path = get_index_path(db_path);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -30,6 +30,7 @@ use progress::{clear_progress, get_progress, ProgressEvent, ProgressStore};
 
 use log::LevelFilter;
 use oauth::AuthState;
+#[cfg(debug_assertions)]
 use specta_typescript::{BigIntExportBehavior, Typescript};
 use sysinfo::SystemExt;
 use tauri::{Manager, Window};

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -72,6 +72,7 @@ pub async fn authenticate(
         .add_extra_param("username", username)
         .set_pkce_challenge(state.auth.pkce.0.clone())
         .url();
+    #[allow(deprecated)] // TODO: migrate to tauri-plugin-opener
     app.shell().open(auth_url, None)?;
     let _server_handle = tauri::async_runtime::spawn(async move { run_server(app).await });
     Ok(())


### PR DESCRIPTION
## Summary
- Gate `specta_typescript` import behind `#[cfg(debug_assertions)]` to fix unused import warning in release builds
- Add `#[allow(deprecated)]` to `shell().open()` call with TODO to migrate to `tauri-plugin-opener`
- Suppress `dead_code` warnings for `White`/`Black` structs (needed for Diesel associations), `MmapSearchIndex` fields/methods, and `decode_moves` function

Release build now compiles with zero warnings.

Closes #659

## Test plan
- [x] `cargo build --release` produces zero warnings
- [ ] Verify application starts and runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)