### PR TITLE
Fix Lichess database JSON parse error on API failures

### DIFF
--- a/src/utils/lichess/api.tsx
+++ b/src/utils/lichess/api.tsx
@@ -362,12 +362,12 @@ export async function getLichessGames(
         : undefined,
     ),
   });
-  const data = await res.json();
-
   if (!res.ok) {
-    throw new Error(`${data}`);
+    throw new Error(
+      `Failed to fetch Lichess games: ${res.status} ${res.statusText}`,
+    );
   }
-  return data;
+  return await res.json();
 }
 
 export async function getMasterGames(
@@ -388,11 +388,12 @@ export async function getMasterGames(
         : undefined,
     ),
   });
-  const data = await res.json();
   if (!res.ok) {
-    throw new Error(`${data}`);
+    throw new Error(
+      `Failed to fetch master games: ${res.status} ${res.statusText}`,
+    );
   }
-  return data;
+  return await res.json();
 }
 
 export async function getPlayerGames(
@@ -401,20 +402,24 @@ export async function getPlayerGames(
   color: Color,
   token?: string,
 ) {
-  return (
-    await fetch(
-      `${explorerURL}/player?fen=${fen}&player=${player}&color=${color}`,
-      {
-        headers: apiHeaders(
-          token
-            ? {
-                Authorization: `Bearer ${token}`,
-              }
-            : undefined,
-        ),
-      },
-    )
-  ).json();
+  const res = await fetch(
+    `${explorerURL}/player?fen=${fen}&player=${player}&color=${color}`,
+    {
+      headers: apiHeaders(
+        token
+          ? {
+              Authorization: `Bearer ${token}`,
+            }
+          : undefined,
+      ),
+    },
+  );
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch player games: ${res.status} ${res.statusText}`,
+    );
+  }
+  return await res.json();
 }
 
 export async function downloadLichess(


### PR DESCRIPTION
## Summary
- Check `res.ok` **before** calling `res.json()` in `getLichessGames()`, `getMasterGames()`, and `getPlayerGames()`
- When Lichess returns an error (rate limit 429, server error 503, etc.), the response is HTML, not JSON. Calling `res.json()` on HTML causes: `SyntaxError: Failed to execute 'close' on 'ReadableStreamDefaultController': Unexpected token '<'`
- Now throws a descriptive error with HTTP status code instead of crashing the JSON parser

Closes #707

## Test plan
- [ ] Open database panel with Lichess All or Lichess Masters selected
- [ ] Verify normal queries work as before
- [ ] Simulate error (e.g., disconnect network) and confirm a clean error message appears instead of a JSON parse crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)