### PR TITLE
Strip [%timestamp] annotations from PGN comments

### DIFF
--- a/src/utils/chess.ts
+++ b/src/utils/chess.ts
@@ -433,7 +433,10 @@ function innerParsePGN(
         root.clock = comment.clock;
       }
 
-      root.comment = comment.text;
+      // Strip [%timestamp N] annotations (chess.com export format) from comment text
+      root.comment = comment.text
+        .replace(/\s?\[%timestamp\s+\d+\]\s?/g, " ")
+        .trim();
     } else if (token.type === "ParenOpen") {
       const variation = [];
       let subvariations = 0;


### PR DESCRIPTION
## Summary
- Strip `[%timestamp N]` annotations from PGN comment text after parsing
- Chess.com exports include both `[%clk 0:09:59.9]` and `[%timestamp 1]` in move comments. The `[%clk]` is already parsed by chessops, but `[%timestamp]` was left in the displayed comment text, cluttering the notation
- The `[%timestamp]` value represents elapsed seconds since game start (not remaining clock time), so it can't be reliably converted to a clock value without time control info. The `[%clk]` value is used for clock display when present

Closes #708

## Test plan
- [x] All 40 existing tests pass
- [ ] Import a chess.com PGN with both `[%clk]` and `[%timestamp]` annotations
- [ ] Verify timestamps are stripped from comments and clock times display correctly
- [ ] Verify PGNs with only `[%clk]` still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)