### PR TITLE
Add divider for Database/Engine Page

### DIFF
--- a/src/components/databases/DatabasesPage.tsx
+++ b/src/components/databases/DatabasesPage.tsx
@@ -200,11 +200,7 @@ export default function DatabasesPage() {
         </ScrollArea>
 
         {selectedDatabase === null ? (
-          <Paper
-            style={{ borderLeft: "2px solid var(--mantine-color-gray-7)" }}
-            p="md"
-            h="100%"
-          >
+          <Paper withBorder style={{ borderWidth: 2 }} p="md" h="100%">
             <Center h="100%">
               <Stack align="center" gap="sm">
                 <ThemeIcon size={80} radius="100%" variant="light" color="gray">
@@ -217,7 +213,7 @@ export default function DatabasesPage() {
             </Center>
           </Paper>
         ) : (
-          <Paper withBorder p="md" h="100%">
+          <Paper withBorder style={{ borderWidth: 2 }} p="md" h="100%">
             <ScrollArea h="100%" offsetScrollbars>
               <Stack>
                 {selectedDatabase.type === "error" ? (

--- a/src/components/engines/EnginesPage.tsx
+++ b/src/components/engines/EnginesPage.tsx
@@ -127,11 +127,7 @@ export default function EnginesPage() {
           </SimpleGrid>
         </ScrollArea>
         {!selectedEngine || selected === undefined ? (
-          <Paper
-            style={{ borderLeft: "2px solid var(--mantine-color-gray-7)" }}
-            p="md"
-            h="100%"
-          >
+          <Paper withBorder style={{ borderWidth: 2 }} p="md" h="100%">
             <Center h="100%">
               <Stack align="center" gap="sm">
                 <ThemeIcon size={80} radius="100%" variant="light" color="gray">
@@ -144,7 +140,7 @@ export default function EnginesPage() {
             </Center>
           </Paper>
         ) : (
-          <Paper withBorder p="md" h="100%">
+          <Paper withBorder style={{ borderWidth: 2 }} p="md" h="100%">
             {selectedEngine.type === "local" ? (
               <EngineSettings selected={selected} setSelected={setSelected} />
             ) : (


### PR DESCRIPTION
Added a vertical divider, because when I first saw this with no engines and databases I was confused and thought the layout was buggy and not centered. Turns out it's for the details/settings of the database/engine. So added a small vertical divider to better signal the two "slots" if the details/settings are not selected.

before:
<img width="2494" height="1338" alt="image" src="https://github.com/user-attachments/assets/1a9b8c69-9579-4c52-b8dd-752db0a25000" />

after:
<img width="2482" height="1323" alt="image" src="https://github.com/user-attachments/assets/59e9c945-db87-4bbf-b78d-a9d4cf0bd571" />
