### PR TITLE
titlebar: resurrect custom titlebar on Linux

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -413,7 +413,7 @@ export default function Page() {
           />
         ),
       },
-      ...(import.meta.env.VITE_PLATFORM === "win32"
+      ...(import.meta.env.VITE_PLATFORM === "win32" || import.meta.env.VITE_PLATFORM === "linux"
         ? [
             {
               id: "title-bar",

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -305,7 +305,10 @@ function RootLayout() {
 
   useEffect(() => {
     if (!menu) return;
-    if (isNative || import.meta.env.VITE_PLATFORM !== "win32") {
+    if (
+      isNative ||
+      (import.meta.env.VITE_PLATFORM !== "win32" && import.meta.env.VITE_PLATFORM !== "linux")
+    ) {
       menu.setAsAppMenu();
       getCurrentWindow().setDecorations(true);
     } else {
@@ -341,7 +344,8 @@ function RootLayout() {
         breakpoint: 0,
       }}
       header={
-        isNative || import.meta.env.VITE_PLATFORM !== "win32"
+        isNative ||
+        (import.meta.env.VITE_PLATFORM !== "win32" && import.meta.env.VITE_PLATFORM !== "linux")
           ? undefined
           : {
               height: "2.25rem",
@@ -355,11 +359,13 @@ function RootLayout() {
       }}
     >
       <AboutModal opened={opened} setOpened={setOpened} />
-      {!isNative && import.meta.env.VITE_PLATFORM === "win32" && (
-        <AppShell.Header>
-          <TopBar menuActions={menuActions} />
-        </AppShell.Header>
-      )}
+      {!isNative &&
+        (import.meta.env.VITE_PLATFORM === "win32" ||
+          import.meta.env.VITE_PLATFORM === "linux") && (
+          <AppShell.Header>
+            <TopBar menuActions={menuActions} />
+          </AppShell.Header>
+        )}
       <AppShell.Navbar>
         <SideBar />
       </AppShell.Navbar>


### PR DESCRIPTION
Previously, the native titlebar was forced for both Linux and macOS[1]. Whilst it still makes sense to force the native titlebar for macOS, desktop Linux varies greatly in desktop environments. As such, given that the custom titlebar seems to work just fine on desktop Linux now, resurrect it for desktop Linux.

Gtk does not support server side decorations — at least under Wayland — regardless, so unlike the native titlebar under macOS and Windows, the native titlebar on Linux uses client side decorations regardless. This means that there isn't actually a difference from the perspective of the compositor in how the titlebar is rendered: the native titlebar simply uses Gtk's default CSD titlebar.

In theory at least, no real issues should be caused by this patch as a result. However, for users that don't like the Custom titlebar, also expose the titlebar option in the settings page for Linux too such that it is possible for a user to revert back to the native titlebar.

[1] https://github.com/franciscoBSalgueiro/en-croissant/commit/e646278abc86211384aa3d15b91f5421a8fb2298