### PR TITLE
Fix board orientation when player plays Black in engine games

### DIFF
--- a/src/components/boards/BoardGame.tsx
+++ b/src/components/boards/BoardGame.tsx
@@ -273,6 +273,11 @@ function BoardGame() {
     const playerSettings = getPlayers();
     setPlayers(playerSettings);
 
+    const boardOrientation =
+      playerSettings.black.type === "human" && playerSettings.white.type === "engine"
+        ? "black"
+        : "white";
+
     const newGameId = `${activeTab}-game`;
     setGameId(newGameId);
 
@@ -355,6 +360,7 @@ function BoardGame() {
         date: dateStr,
         time: timeStr,
         time_control: undefined,
+        orientation: boardOrientation,
       };
 
       if (sameTimeControl) {


### PR DESCRIPTION
# Fix board orientation when player plays Black in engine games

## Summary

When starting a game vs engine with colour set to **black** or **random** (and randomly assigned Black), the board orientation was always shown from White's perspective instead of flipping to Black's.

`startGame()` never wrote an `orientation` value to the game headers, so the board defaulted to `"white"` on every new game regardless of which colour the human was assigned.

## Changes

- Derive `boardOrientation` from the resolved player settings after colour assignment — `"black"` when the human is playing Black against an engine, `"white"` otherwise.
- Include `orientation: boardOrientation` in the headers written at game start, so the board immediately reflects the correct perspective.

## Behaviour

| Scenario | Orientation |
|---|---|
| Player chooses White | White |
| Player chooses Black | Black |
| Player chooses Random → assigned White | White |
| Player chooses Random → assigned Black | Black |
| Human vs Human | White (unchanged) |
| Engine vs Engine | White (unchanged) |