### PR TITLE
Fix: engine settings changes not applied to new games

### DIFF
--- a/src/components/boards/EnginesSelect.tsx
+++ b/src/components/boards/EnginesSelect.tsx
@@ -15,8 +15,14 @@ export function EnginesSelect({
   const engines = (allEngines ?? []).filter((e): e is LocalEngine => e.type === "local");
 
   useEffect(() => {
-    if (engines.length > 0 && engine === null) {
+    if (engines.length === 0) return;
+    if (engine === null) {
       setEngine(engines[0]);
+    } else {
+      const updatedEngine = engines.find((e) => e.id === engine.id);
+      if (updatedEngine && updatedEngine !== engine) {
+        setEngine(updatedEngine);
+      }
     }
   }, [engine, engines, setEngine]);
 


### PR DESCRIPTION
## Problem

When a user updates engine settings on the Engines page, starting a new game still uses the old settings. Clearing saved data fixes it as a workaround.

## Solution

When the engine list updates, sync the selected engine to its latest version.

## Notes

Any per-game engine setting overrides will be cleared when global engine settings are saved.