### PR TITLE
Add missing value on en-US translation

### DIFF
--- a/src/translation/en-US.json
+++ b/src/translation/en-US.json
@@ -349,7 +349,7 @@
     "Files.FileType.Tournament": "Tournament",
     "Files.GameCountSuffix_one": "{{number}} game",
     "Files.GameCountSuffix_other": "{{number}} games",
-    "Files.LoadingFailed": "",
+    "Files.LoadingFailed": "Failed to load file",
     "Files.NoSelection": "No file selected",
     "Files.Reload": "Reload file",
     "Files.Title": "Files",


### PR DESCRIPTION
Fixes translation omission from my previous PR which was highlighted by a user on discord. [Link to message](https://discord.com/channels/1061658842200547390/1275268406010056804/1486250904599662592)