### PR TITLE
Fix regex in the chess.com link import

### DIFF
--- a/src/utils/chess.com/api.tsx
+++ b/src/utils/chess.com/api.tsx
@@ -157,7 +157,7 @@ const chessComGameSchema = z.object({
 });
 
 export async function getChesscomGame(gameURL: string) {
-  const regex = /.*\/game\/(live|daily)\/(\d+)/;
+  const regex = /.*\/game\/(?:(live|daily)\/)?(\d+)/;
   const match = gameURL.match(regex);
 
   if (!match) {
@@ -183,7 +183,7 @@ export async function getChesscomGame(gameURL: string) {
     return null;
   }
 
-  const gameType = match[1];
+  const gameType = match[1] || "live";
   const gameId = match[2];
 
   const response = await fetch(`https://www.chess.com/callback/${gameType}/game/${gameId}`, {


### PR DESCRIPTION
The Problem: The previous regex required a /live/ segment (e.g., chess.com/live/12345), which does not always exist immediately after a non-daily game finishes.

The Fix: Modified the regex to accept both the existing prefixes and the standard post-game URL format.