### PR TITLE
fix: parse PGN date format correctly in RatingsPanel

### DIFF
--- a/src/components/home/PersonalCardPanels/RatingsPanel.tsx
+++ b/src/components/home/PersonalCardPanels/RatingsPanel.tsx
@@ -9,6 +9,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import dayjs from "dayjs";
 import type { PlayerGameInfo } from "@/bindings";
 import { getTimeControl } from "@/utils/timeControl";
 import DateRangeTabs, { DateRange } from "./DateRangeTabs";
@@ -69,7 +70,7 @@ function RatingsPanel({
           .filter(
             (game) => !timeControl || getTimeControl(website, game.time_control) === timeControl,
           )
-          .map((game) => new Date(game.date).getTime()),
+          .map((game) => dayjs(game.date, "YYYY.MM.DD").valueOf()),
       ]),
     ).sort((a, b) => a - b);
   }, [info.site_stats_data, website, account, timeControl]);
@@ -94,7 +95,7 @@ function RatingsPanel({
           (game) => !timeControl || getTimeControl(website!, game.time_control) === timeControl,
         )
         .filter((game) => {
-          const gameDate = new Date(game.date).getTime();
+          const gameDate = dayjs(game.date, "YYYY.MM.DD").valueOf();
           return (
             gameDate >= (dates[timeRange.start] || 0) && gameDate <= (dates[timeRange.end] || 0)
           );
@@ -108,7 +109,7 @@ function RatingsPanel({
     const ratingData = (() => {
       const map = new Map<number, { date: number; player_elo: number }>();
       for (const game of filteredGames) {
-        const date = new Date(game.date).getTime();
+        const date = dayjs(game.date, "YYYY.MM.DD").valueOf();
         if (!map.has(date) || map.get(date)!.player_elo < game.player_elo) {
           map.set(date, { date, player_elo: game.player_elo });
         }


### PR DESCRIPTION
Fixes #768

- Database dates are stored in PGN format (`YYYY.MM.DD`), but `new Date()` cannot parse dot-separated dates, returning `NaN`
- This caused the Ratings tab to show "0 Games" and the date range slider to display "Invalid Date"
- Replaced 3 instances of `new Date(game.date)` with `dayjs(game.date, "YYYY.MM.DD")`, matching the parsing pattern used throughout the rest of the codebase
