### PR TITLE
Add Zen Mode for distraction-free board view (fixes #783)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 "use no memo";
-import { AppShellSection, Stack, Tooltip } from "@mantine/core";
+import { AppShellSection, Stack, Tooltip, UnstyledButton } from "@mantine/core";
 import {
   type Icon,
   IconChess,
@@ -8,10 +8,13 @@ import {
   IconFiles,
   IconSettings,
   IconUser,
+  IconYoga,
 } from "@tabler/icons-react";
 import { Link, useMatchRoute } from "@tanstack/react-router";
 import cx from "clsx";
+import { useAtom } from "jotai";
 import { useTranslation } from "react-i18next";
+import { zenModeAtom } from "@/state/atoms";
 import classes from "./Sidebar.module.css";
 
 interface NavbarLinkProps {
@@ -51,6 +54,7 @@ const linksdata = [
 
 export function SideBar() {
   const { t } = useTranslation();
+  const [zenMode, setZenMode] = useAtom(zenModeAtom);
 
   const links = linksdata.map((link) => (
     <NavbarLink {...link} label={t(`SideBar.${link.label}`)} key={link.label} />
@@ -65,6 +69,14 @@ export function SideBar() {
       </AppShellSection>
       <AppShellSection>
         <Stack justify="center" gap={0}>
+          <Tooltip label="Zen Mode (Shift+Z, Esc to exit)" position="right">
+            <UnstyledButton
+              className={cx(classes.link, { [classes.active]: zenMode })}
+              onClick={() => setZenMode((v) => !v)}
+            >
+              <IconYoga size="1.5rem" stroke={1.5} />
+            </UnstyledButton>
+          </Tooltip>
           <NavbarLink icon={IconSettings} label={t("SideBar.Settings")} url="/settings" />
         </Stack>
       </AppShellSection>

--- a/src/components/boards/Board.tsx
+++ b/src/components/boards/Board.tsx
@@ -44,6 +44,7 @@ import {
   showDestsAtom,
   showVariationArrowsAtom,
   snapArrowsAtom,
+  zenModeAtom,
 } from "@/state/atoms";
 import { keyMapAtom } from "@/state/keybinds";
 import classes from "@/styles/Chessboard.module.css";
@@ -140,6 +141,7 @@ function Board({
   const forcedEP = useAtomValue(forcedEnPassantAtom);
   const showCoordinates = useAtomValue(showCoordinatesAtom);
   const materialDisplay = useAtomValue(materialDisplayAtom);
+  const zenMode = useAtomValue(zenModeAtom);
 
   let dests: Map<SquareName, SquareName[]> = pos ? chessgroundDests(pos) : new Map();
   if (forcedEP && pos) {
@@ -379,7 +381,7 @@ function Board({
 
   return (
     <>
-      <Box w="100%" h="100%">
+      <Box w="100%" h="100%" style={zenMode ? { display: "flex", justifyContent: "center" } : undefined}>
         <Box
           style={{
             display: "flex",
@@ -389,9 +391,10 @@ function Board({
             gap: "0.5rem",
             flexWrap: "nowrap",
             overflow: "hidden",
-            maxWidth:
-              //            topbar   bottompadding                tabs                                  bottomb    topbar   evalbar                                gaps    ???
-              `calc(100vh - 2.25rem - var(--mantine-spacing-sm) - 2.5rem - var(--mantine-spacing-sm) - ${BAR_HEIGHT} - ${BAR_HEIGHT} + 1.563rem + var(--mantine-spacing-md) - 1rem  - 0.2rem)`,
+            maxWidth: zenMode
+              ? `calc(100vh - ${BAR_HEIGHT} - ${BAR_HEIGHT} - 0.5rem)`
+              : //            topbar   bottompadding                tabs                                  bottomb    topbar   evalbar                                gaps    ???
+                `calc(100vh - 2.25rem - var(--mantine-spacing-sm) - 2.5rem - var(--mantine-spacing-sm) - ${BAR_HEIGHT} - ${BAR_HEIGHT} + 1.563rem + var(--mantine-spacing-md) - 1rem  - 0.2rem)`,
           }}
         >
           <BoardBar

--- a/src/components/boards/Board.tsx
+++ b/src/components/boards/Board.tsx
@@ -381,7 +381,11 @@ function Board({
 
   return (
     <>
-      <Box w="100%" h="100%" style={zenMode ? { display: "flex", justifyContent: "center" } : undefined}>
+      <Box
+        w="100%"
+        h="100%"
+        style={zenMode ? { display: "flex", justifyContent: "center" } : undefined}
+      >
         <Box
           style={{
             display: "flex",

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -59,6 +59,7 @@ import {
   storedEnginesDirAtom,
   storedPuzzlesDirAtom,
   telemetryEnabledAtom,
+  zenModeAtom,
 } from "@/state/atoms";
 import { keyMapAtom } from "@/state/keybinds";
 import FileInput from "../common/FileInput";
@@ -183,6 +184,14 @@ export default function Page() {
   const settings: SettingItem[] = useMemo(
     () => [
       // Board settings
+      {
+        id: "zen-mode",
+        category: "board",
+        title: "Zen Mode",
+        description: "Hide UI panels and maximize the board (Shift+Z)",
+        keywords: ["zen", "focus", "distraction", "fullscreen", "minimal", "hide"],
+        render: () => <SettingsSwitch atom={zenModeAtom} />,
+      },
       {
         id: "piece-dest",
         category: "board",

--- a/src/components/tabs/BoardsPage.tsx
+++ b/src/components/tabs/BoardsPage.tsx
@@ -3,12 +3,12 @@ import { ActionIcon, ScrollArea, Tabs } from "@mantine/core";
 import { useHotkeys, useToggle } from "@mantine/hooks";
 import { IconPlus } from "@tabler/icons-react";
 import { useAtom, useAtomValue } from "jotai";
-import { type ReactNode, startTransition, useCallback, useEffect } from "react";
+import { type ReactNode, startTransition, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Mosaic, type MosaicNode } from "react-mosaic-component";
 import { match } from "ts-pattern";
 import { commands } from "@/bindings";
-import { activeTabAtom, tabsAtom } from "@/state/atoms";
+import { activeTabAtom, tabsAtom, zenModeAtom } from "@/state/atoms";
 import { keyMapAtom } from "@/state/keybinds";
 import { createTab, genID, isPersistentGameOrigin, type Tab } from "@/utils/tabs";
 import { unwrap } from "@/utils/unwrap";
@@ -33,6 +33,7 @@ export default function BoardsPage() {
   const [tabs, setTabs] = useAtom(tabsAtom);
   const [activeTab, setActiveTab] = useAtom(activeTabAtom);
   const [saveModalOpened, toggleSaveModal] = useToggle();
+  const zenMode = useAtomValue(zenModeAtom);
 
   useEffect(() => {
     if (tabs.length === 0) {
@@ -187,7 +188,7 @@ export default function BoardsPage() {
       keepMounted={false}
       className={classes.tabsContainer}
     >
-      <ScrollArea scrollbarSize={6} className={classes.tabsHeader}>
+      <ScrollArea scrollbarSize={6} className={classes.tabsHeader} style={{ display: zenMode ? "none" : undefined }}>
         <DragDropContext
           onDragEnd={({ destination, source }) =>
             destination?.index !== undefined &&
@@ -302,28 +303,33 @@ function TabSwitch({
   activeTab: string | null;
 }) {
   const [windowsState, setWindowsState] = useAtom(windowsStateAtom);
+  const zenMode = useAtomValue(zenModeAtom);
+
+  const effectiveMosaicNode = useMemo(() => {
+    if (!zenMode || !windowsState.currentNode) return windowsState.currentNode;
+    if (typeof windowsState.currentNode === "string") return windowsState.currentNode;
+    return { ...windowsState.currentNode, splitPercentage: 100 };
+  }, [zenMode, windowsState.currentNode]);
+
+  const mosaicProps = {
+    renderTile: (id: string) => fullLayout[id],
+    value: effectiveMosaicNode,
+    onChange: (currentNode: MosaicNode<ViewId> | null) => setWindowsState({ currentNode }),
+    resize: { minimumPaneSizePercentage: 0 },
+    className: zenMode ? "zen-mode" : undefined,
+  };
 
   return match(tab.type)
     .with("new", () => <NewTabHome id={tab.value} />)
     .with("play", () => (
       <TreeStateProvider id={tab.value}>
-        <Mosaic<ViewId>
-          renderTile={(id) => fullLayout[id]}
-          value={windowsState.currentNode}
-          onChange={(currentNode) => setWindowsState({ currentNode })}
-          resize={{ minimumPaneSizePercentage: 0 }}
-        />
+        <Mosaic<ViewId> {...mosaicProps} />
         <BoardGame />
       </TreeStateProvider>
     ))
     .with("analysis", () => (
       <TreeStateProvider id={tab.value}>
-        <Mosaic<ViewId>
-          renderTile={(id) => fullLayout[id]}
-          value={windowsState.currentNode}
-          onChange={(currentNode) => setWindowsState({ currentNode })}
-          resize={{ minimumPaneSizePercentage: 0 }}
-        />
+        <Mosaic<ViewId> {...mosaicProps} />
         <BoardAnalysis />
         <ConfirmChangesModal
           opened={saveModalOpened}
@@ -334,12 +340,7 @@ function TabSwitch({
     ))
     .with("puzzles", () => (
       <TreeStateProvider id={tab.value}>
-        <Mosaic<ViewId>
-          renderTile={(id) => fullLayout[id]}
-          value={windowsState.currentNode}
-          onChange={(currentNode) => setWindowsState({ currentNode })}
-          resize={{ minimumPaneSizePercentage: 0 }}
-        />
+        <Mosaic<ViewId> {...mosaicProps} />
         <Puzzles id={tab.value} />
       </TreeStateProvider>
     ))

--- a/src/components/tabs/BoardsPage.tsx
+++ b/src/components/tabs/BoardsPage.tsx
@@ -188,7 +188,11 @@ export default function BoardsPage() {
       keepMounted={false}
       className={classes.tabsContainer}
     >
-      <ScrollArea scrollbarSize={6} className={classes.tabsHeader} style={{ display: zenMode ? "none" : undefined }}>
+      <ScrollArea
+        scrollbarSize={6}
+        className={classes.tabsHeader}
+        style={{ display: zenMode ? "none" : undefined }}
+      >
         <DragDropContext
           onDragEnd={({ destination, source }) =>
             destination?.index !== undefined &&

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import { AppShell } from "@mantine/core";
+import { AppShell, Tooltip } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { createRootRouteWithContext, Outlet, useNavigate } from "@tanstack/react-router";
 import { TauriEvent } from "@tauri-apps/api/event";
@@ -20,7 +20,7 @@ import type { Dirs } from "@/App";
 import AboutModal from "@/components/About";
 import { SideBar } from "@/components/Sidebar";
 import TopBar from "@/components/TopBar";
-import { activeTabAtom, nativeBarAtom, tabsAtom } from "@/state/atoms";
+import { activeTabAtom, nativeBarAtom, tabsAtom, zenModeAtom } from "@/state/atoms";
 import { keyMapAtom } from "@/state/keybinds";
 import { openFile } from "@/utils/files";
 import { createTab } from "@/utils/tabs";
@@ -141,8 +141,13 @@ function RootLayout() {
 
   const [keyMap] = useAtom(keyMapAtom);
 
+  const [zenMode, setZenMode] = useAtom(zenModeAtom);
   useHotkeys(keyMap.NEW_TAB.keys, createNewTab);
   useHotkeys(keyMap.OPEN_FILE.keys, openNewFile);
+  useHotkeys(keyMap.ZEN_MODE.keys, () => setZenMode((v) => !v));
+  useHotkeys("Escape", () => {
+    if (zenMode) setZenMode(false);
+  });
   const [opened, setOpened] = useState(false);
 
   const isMacOS = platform() === "macos";
@@ -356,6 +361,7 @@ function RootLayout() {
       navbar={{
         width: "3rem",
         breakpoint: 0,
+        collapsed: { desktop: zenMode, mobile: zenMode },
       }}
       header={
         isNative ||
@@ -363,6 +369,7 @@ function RootLayout() {
           ? undefined
           : {
               height: "2.25rem",
+              collapsed: zenMode,
             }
       }
       styles={{
@@ -385,6 +392,26 @@ function RootLayout() {
       </AppShell.Navbar>
       <AppShell.Main>
         <Outlet />
+        {zenMode && (
+          <Tooltip
+            label="Zen Mode active — Shift+Z to toggle, Esc to exit"
+            position="right"
+            openDelay={1000}
+          >
+            <div
+              style={{
+                position: "fixed",
+                left: 0,
+                top: 0,
+                width: "6px",
+                height: "100vh",
+                zIndex: 1000,
+                cursor: "pointer",
+              }}
+              onClick={() => setZenMode(false)}
+            />
+          </Tooltip>
+        )}
       </AppShell.Main>
     </AppShell>
   );

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -187,6 +187,7 @@ export const previewBoardOnHoverAtom = atomWithStorage<boolean>("preview-board-o
 export const enableBoardScrollAtom = atomWithStorage<boolean>("board-scroll", true);
 export const materialDisplayAtom = atomWithStorage<"diff" | "all">("material-display", "diff");
 export const forcedEnPassantAtom = atomWithStorage<boolean>("forced-ep", false);
+export const zenModeAtom = atomWithStorage<boolean>("zen-mode", false);
 export const showCoordinatesAtom = atomWithStorage<"no" | "edge" | "all">(
     "show-coordinates-v2",
     "no",

--- a/src/state/keybinds.ts
+++ b/src/state/keybinds.ts
@@ -52,6 +52,7 @@ const keys: KeyMap = {
     ANNOTATION_BLUNDER: { name: "Toggle blunder move annotation", keys: "6" },
     TOGGLE_ALL_ENGINES: { name: "Toggle all engines", keys: "ctrl+a" },
     TOGGLE_BLUR: { name: "Toggle blur", keys: "ctrl+b" },
+    ZEN_MODE: { name: "Toggle Zen Mode", keys: "shift+z" },
     GENERATE_REPORT: { name: "Generate game report", keys: "f12" },
     PREVIOUS_GAME: { name: "Previous game", keys: "pageup" },
     NEXT_GAME: { name: "Next game", keys: "pagedown" },

--- a/src/styles/react-mosaic.css
+++ b/src/styles/react-mosaic.css
@@ -13,3 +13,7 @@
 .mosaic-split:hover .mosaic-split-line {
   box-shadow: 0 0 0 1px var(--mantine-primary-color-filled) !important;
 }
+
+.zen-mode .mosaic-split {
+  display: none;
+}


### PR DESCRIPTION
## Summary

- Adds a **Zen Mode** that hides all UI chrome (sidebar, top bar, tabs, analysis/notation panels) and centers the board for a distraction-free experience
- Toggle via **Shift+Z** keyboard shortcut or **yoga icon** in the sidebar; **Escape** to exit
- Board auto-centers and expands to fill available space
- Persisted in localStorage, works across analysis, play, and puzzle modes
- Hovering the left edge in zen mode shows a reminder tooltip after 1 second
- Also available as a toggle in **Settings > Board > Zen Mode**

Closes #783

## Implementation notes

- Uses Mantine AppShell's native `collapsed` prop for sidebar/header — no CSS hacks
- Overrides mosaic `splitPercentage` to 100 in zen mode so portal targets stay in the DOM (preserves keyboard shortcuts and panel state)
- Persisted layout is never modified — exiting zen mode restores the user's exact panel arrangement

## Icon note

The sidebar toggle uses the **IconYoga** (meditation pose) from [Tabler Icons](https://tabler.io/icons/icon/yoga) by Paweł Kuna, which is MIT licensed — same as the rest of the Tabler icon set already used throughout the project.

## Test plan

- [ ] Press Shift+Z in analysis view — sidebar, top bar, tabs, and side panels hide; board centers
- [ ] Press Escape or Shift+Z again — full UI restores with previous panel layout intact
- [ ] Click yoga icon in sidebar — same toggle behavior
- [ ] Hover left edge in zen mode for ~1 second — tooltip appears
- [ ] Click left edge in zen mode — exits zen mode
- [ ] Arrow keys still navigate moves while in zen mode
- [ ] Test in play mode and puzzle mode
- [ ] Toggle in Settings > Board > Zen Mode
- [ ] Resize window while in zen mode — board stays properly sized and centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)