### PR TITLE
Engine ratings

### DIFF
--- a/src-tauri/src/engine/process.rs
+++ b/src-tauri/src/engine/process.rs
@@ -99,7 +99,6 @@ impl BaseEngine {
     pub async fn send(&mut self, cmd: &str) -> Result<(), Error> {
         self.log_gui(cmd);
         let msg = format!("{}\n", cmd);
-        println!("{}",msg);
         self.stdin.write_all(msg.as_bytes()).await?;
         Ok(())
     }
@@ -114,7 +113,6 @@ impl BaseEngine {
                 return Err(Error::EngineDisconnected);
             };
             self.logs.push(EngineLog::Engine(line.clone()));
-            print!("{}",line);
             if line.starts_with(expected) {
                 return Ok(());
             }

--- a/src-tauri/src/engine/process.rs
+++ b/src-tauri/src/engine/process.rs
@@ -99,6 +99,7 @@ impl BaseEngine {
     pub async fn send(&mut self, cmd: &str) -> Result<(), Error> {
         self.log_gui(cmd);
         let msg = format!("{}\n", cmd);
+        println!("{}",msg);
         self.stdin.write_all(msg.as_bytes()).await?;
         Ok(())
     }
@@ -113,6 +114,7 @@ impl BaseEngine {
                 return Err(Error::EngineDisconnected);
             };
             self.logs.push(EngineLog::Engine(line.clone()));
+            print!("{}",line);
             if line.starts_with(expected) {
                 return Ok(());
             }

--- a/src/components/boards/EnginesSelect.tsx
+++ b/src/components/boards/EnginesSelect.tsx
@@ -1,8 +1,11 @@
 import { Select } from "@mantine/core";
-import { useAtomValue } from "jotai";
+import { useAtom } from "jotai";
 import { useEffect } from "react";
 import { enginesAtom } from "@/state/atoms";
-import type { LocalEngine } from "@/utils/engines";
+import { requiredEngineSettings, type LocalEngine } from "@/utils/engines";
+import useSWRImmutable from "swr/immutable";
+import { commands } from "@/bindings";
+import { unwrap } from "@/utils/unwrap";
 
 export function EnginesSelect({
   engine,
@@ -11,8 +14,47 @@ export function EnginesSelect({
   engine: LocalEngine | null;
   setEngine: (engine: LocalEngine | null) => void;
 }) {
-  const allEngines = useAtomValue(enginesAtom);
+  const [allEngines, setAllEngines] = useAtom(enginesAtom);
   const engines = (allEngines ?? []).filter((e): e is LocalEngine => e.type === "local");
+  const { data: options } = useSWRImmutable(["engine-config", engine?.path], async ([, path]) => {
+    return unwrap(await commands.getEngineConfig(String(path)));
+  });
+  useEffect(() => {
+    if (options && engine) {
+      const settings = [...(engine.settings || [])];
+      const missing = requiredEngineSettings.filter(
+        (field) => !settings.find((setting) => setting.name === field),
+      );
+      for (const field of requiredEngineSettings) {
+        if (!settings.find((setting) => setting.name === field)) {
+          const option = options.options.find((option) => option.value.name === field);
+          if (option && option.type !== "button") {
+            if (option.type == "spin") {
+              settings.push({
+                name: field,
+                value: option.value.default as string | number | boolean | null,
+                min: option.value.min as number | null,
+                max: option.value.max as number | null,
+              });
+            } else {
+              settings.push({
+                name: field,
+                value: option.value.default as string | number | boolean | null,
+              });
+            }
+          }
+        }
+      }
+      if (missing.length > 0 && allEngines) {
+        const newEngine = { ...engine, settings };
+        setAllEngines(async (prev) => {
+          const copy = [...(await prev)];
+          copy[allEngines.findIndex((o) => o == engine)] = newEngine;
+          return copy;
+        });
+      }
+    }
+  }, [options]);
 
   useEffect(() => {
     if (engines.length === 0) return;

--- a/src/components/engines/AddEngine.tsx
+++ b/src/components/engines/AddEngine.tsx
@@ -236,8 +236,8 @@ function EngineCard({
               name: o.value.name,
               // @ts-expect-error
               value: o.value.default,
-              min: o.type == "spin" ? Number(o.value.min): null,
-              max: o.type == "spin" ? Number(o.value.max): null,
+              min: o.type == "spin" ? Number(o.value.min) : null,
+              max: o.type == "spin" ? Number(o.value.max) : null,
             })),
         },
       ]);

--- a/src/components/engines/AddEngine.tsx
+++ b/src/components/engines/AddEngine.tsx
@@ -177,8 +177,6 @@ function CloudCard({ engine }: { engine: RemoteEngine }) {
                     {
                       name: "MultiPV",
                       value: "1",
-                      min: null,
-                      max: null,
                     },
                   ],
                 },

--- a/src/components/engines/AddEngine.tsx
+++ b/src/components/engines/AddEngine.tsx
@@ -177,6 +177,8 @@ function CloudCard({ engine }: { engine: RemoteEngine }) {
                     {
                       name: "MultiPV",
                       value: "1",
+                      min: null,
+                      max: null,
                     },
                   ],
                 },
@@ -234,6 +236,8 @@ function EngineCard({
               name: o.value.name,
               // @ts-expect-error
               value: o.value.default,
+              min: o.type == "spin" ? Number(o.value.min): null,
+              max: o.type == "spin" ? Number(o.value.max): null,
             })),
         },
       ]);

--- a/src/components/engines/EnginesPage.tsx
+++ b/src/components/engines/EnginesPage.tsx
@@ -292,10 +292,19 @@ function EngineSettings({
         if (!settings.find((setting) => setting.name === field)) {
           const option = options.options.find((option) => option.value.name === field);
           if (option && option.type !== "button") {
+            if(option.type == "spin"){
+              settings.push({
+              name: field,
+              value: option.value.default as string | number | boolean | null,
+              min: option.value.min as number | null,
+              max: option.value.max as number | null,
+            });
+            } else{
             settings.push({
               name: field,
               value: option.value.default as string | number | boolean | null,
             });
+          }
           }
         }
       }

--- a/src/components/engines/EnginesPage.tsx
+++ b/src/components/engines/EnginesPage.tsx
@@ -292,19 +292,19 @@ function EngineSettings({
         if (!settings.find((setting) => setting.name === field)) {
           const option = options.options.find((option) => option.value.name === field);
           if (option && option.type !== "button") {
-            if(option.type == "spin"){
+            if (option.type == "spin") {
               settings.push({
-              name: field,
-              value: option.value.default as string | number | boolean | null,
-              min: option.value.min as number | null,
-              max: option.value.max as number | null,
-            });
-            } else{
-            settings.push({
-              name: field,
-              value: option.value.default as string | number | boolean | null,
-            });
-          }
+                name: field,
+                value: option.value.default as string | number | boolean | null,
+                min: option.value.min as number | null,
+                max: option.value.max as number | null,
+              });
+            } else {
+              settings.push({
+                name: field,
+                value: option.value.default as string | number | boolean | null,
+              });
+            }
           }
         }
       }

--- a/src/components/engines/EnginesPage.tsx
+++ b/src/components/engines/EnginesPage.tsx
@@ -294,19 +294,19 @@ function EngineSettings({
         if (!settings.find((setting) => setting.name === field)) {
           const option = options.options.find((option) => option.value.name === field);
           if (option && option.type !== "button") {
-            if(option.type == "spin"){
+            if (option.type == "spin") {
               settings.push({
-              name: field,
-              value: option.value.default as string | number | boolean | null,
-              min: option.value.min as number | null,
-              max: option.value.max as number | null,
-            });
-            } else{
-            settings.push({
-              name: field,
-              value: option.value.default as string | number | boolean | null,
-            });
-          }
+                name: field,
+                value: option.value.default as string | number | boolean | null,
+                min: option.value.min as number | null,
+                max: option.value.max as number | null,
+              });
+            } else {
+              settings.push({
+                name: field,
+                value: option.value.default as string | number | boolean | null,
+              });
+            }
           }
         }
       }

--- a/src/components/engines/EnginesPage.tsx
+++ b/src/components/engines/EnginesPage.tsx
@@ -294,10 +294,19 @@ function EngineSettings({
         if (!settings.find((setting) => setting.name === field)) {
           const option = options.options.find((option) => option.value.name === field);
           if (option && option.type !== "button") {
+            if(option.type == "spin"){
+              settings.push({
+              name: field,
+              value: option.value.default as string | number | boolean | null,
+              min: option.value.min as number | null,
+              max: option.value.max as number | null,
+            });
+            } else{
             settings.push({
               name: field,
               value: option.value.default as string | number | boolean | null,
             });
+          }
           }
         }
       }

--- a/src/components/panels/analysis/EloSlider.tsx
+++ b/src/components/panels/analysis/EloSlider.tsx
@@ -1,6 +1,6 @@
 import { rem, Slider } from "@mantine/core";
 import { IconGripVertical } from "@tabler/icons-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 export default function EloSlider(props: {
   minElo: number;

--- a/src/components/panels/analysis/EloSlider.tsx
+++ b/src/components/panels/analysis/EloSlider.tsx
@@ -1,0 +1,40 @@
+import { rem, Slider } from "@mantine/core";
+import { IconGripVertical } from "@tabler/icons-react";
+import { useEffect, useState } from "react";
+
+export default function EloSlider(props: {
+  value: number;
+  setValue: (v: number) => void;
+  color?: string;
+}) {
+  const [tempValue, setTempValue] = useState(props.value);
+
+  return (
+    <>
+      <Slider
+        min={0}
+        max={props.value}
+        color={props.color}
+        value={tempValue}
+        onChange={setTempValue}
+        onChangeEnd={(v) => props.setValue(v)}
+        label={(v) => v}
+        thumbChildren={
+          <IconGripVertical style={{ width: rem(20), height: rem(20) }} stroke={1.5} />
+        }
+        styles={(theme) => ({
+          mark: {
+            display: "flex",
+          },
+          thumb: {
+            width: rem(20),
+            height: rem(20),
+            backgroundColor: theme.white,
+            color: theme.colors.gray[5],
+            border: `1px solid ${theme.colors.gray[2]}`,
+          },
+        })}
+      />
+    </>
+  );
+}

--- a/src/components/panels/analysis/EloSlider.tsx
+++ b/src/components/panels/analysis/EloSlider.tsx
@@ -3,7 +3,7 @@ import { IconGripVertical } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
 
 export default function EloSlider(props: {
-  minElo : number
+  minElo: number;
   value: number;
   setValue: (v: number) => void;
   color?: string;

--- a/src/components/panels/analysis/EloSlider.tsx
+++ b/src/components/panels/analysis/EloSlider.tsx
@@ -3,6 +3,7 @@ import { IconGripVertical } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
 
 export default function EloSlider(props: {
+  minElo : number
   value: number;
   setValue: (v: number) => void;
   color?: string;
@@ -12,7 +13,7 @@ export default function EloSlider(props: {
   return (
     <>
       <Slider
-        min={0}
+        min={props.minElo}
         max={props.value}
         color={props.color}
         value={tempValue}

--- a/src/components/panels/analysis/EngineSettingsForm.tsx
+++ b/src/components/panels/analysis/EngineSettingsForm.tsx
@@ -49,8 +49,9 @@ function EngineSettingsForm({
 }: EngineSettingsProps) {
   const { t } = useTranslation();
 
-  const [limitStrength, setLimtStrength] = useState<any> (settings.settings.find((o) => o.name === "UCI_LimitStrength"))
-  const maxElo = engine.elo;
+  const limitStrength = settings.settings.find((o) => o.name === "UCI_LimitStrength");
+  const maxElo = settings.settings.find((o) => o.name === "UCI_Elo")?.max
+  const minElo = settings.settings.find((o) => o.name === "UCI_Elo")?.min
   const multipv = settings.settings.find((o) => o.name === "MultiPV");
   const threads = settings.settings.find((o) => o.name === "Threads");
   const hash = settings.settings.find((o) => o.name === "Hash");
@@ -135,22 +136,18 @@ function EngineSettingsForm({
           )}
           <Checkbox
           label={"Adjust Engine rating"}
-          checked={limitStrength}
+          checked={Boolean(limitStrength?.value)}
           onChange={(e) => {
-            const checked = e.target.checked;
-            setLimtStrength(checked)
-            if (checked) {
               setSettings((prev) => ({
             ...prev,
             settings: prev.settings.map((o) =>
               o.name === "UCI_LimitStrength" ? { ...o, value: e.target.checked } : o,
             ),
           }))
-            }
           }}
                                     />
-          {limitStrength && maxElo &&(
-            <EloSlider value={maxElo}
+          {limitStrength?.value && maxElo &&(
+            <EloSlider value={maxElo} minElo={Number(minElo)}
                 setValue={(v) =>
                   setSettings((prev) => ({
                     ...prev,

--- a/src/components/panels/analysis/EngineSettingsForm.tsx
+++ b/src/components/panels/analysis/EngineSettingsForm.tsx
@@ -19,6 +19,7 @@ import { type Engine, type EngineSettings, killEngine } from "@/utils/engines";
 import CoresSlider from "./CoresSlider";
 import HashSlider from "./HashSlider";
 import LinesSlider from "./LinesSlider";
+import EloSlider from "./EloSlider";
 
 export type Settings = {
   enabled: boolean;
@@ -49,6 +50,7 @@ function EngineSettingsForm({
   const { t } = useTranslation();
 
   const [limitStrength, setLimtStrength] = useState<any> (settings.settings.find((o) => o.name === "UCI_LimitStrength"))
+  const maxElo = engine.elo;
   const multipv = settings.settings.find((o) => o.name === "MultiPV");
   const threads = settings.settings.find((o) => o.name === "Threads");
   const hash = settings.settings.find((o) => o.name === "Hash");
@@ -147,8 +149,18 @@ function EngineSettingsForm({
             }
           }}
                                     />
-          {limitStrength && (
-            <h1> Can Limit Strength! </h1>
+          {limitStrength && maxElo &&(
+            <EloSlider value={maxElo}
+                setValue={(v) =>
+                  setSettings((prev) => ({
+                    ...prev,
+                    settings: prev.settings.map((o) =>
+                      o.name === "UCI_Elo" ? { ...o, value: v || 1} : o,
+                    ),
+                  }))
+                }
+                color={color}
+              />
           )}
         </>
       )}

--- a/src/components/panels/analysis/EngineSettingsForm.tsx
+++ b/src/components/panels/analysis/EngineSettingsForm.tsx
@@ -10,7 +10,7 @@ import {
 import { IconPlayerStopFilled, IconSettings } from "@tabler/icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useAtomValue } from "jotai";
-import { memo, useCallback, useMemo } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { GoMode } from "@/bindings";
 import GoModeInput from "@/components/common/GoModeInput";
@@ -48,6 +48,7 @@ function EngineSettingsForm({
 }: EngineSettingsProps) {
   const { t } = useTranslation();
 
+  const [limitStrength, setLimtStrength] = useState<any> (settings.settings.find((o) => o.name === "UCI_LimitStrength"))
   const multipv = settings.settings.find((o) => o.name === "MultiPV");
   const threads = settings.settings.find((o) => o.name === "Threads");
   const hash = settings.settings.find((o) => o.name === "Hash");
@@ -129,6 +130,25 @@ function EngineSettingsForm({
                 color={color}
               />
             </Group>
+          )}
+          <Checkbox
+          label={"Adjust Engine rating"}
+          checked={limitStrength}
+          onChange={(e) => {
+            const checked = e.target.checked;
+            setLimtStrength(checked)
+            if (checked) {
+              setSettings((prev) => ({
+            ...prev,
+            settings: prev.settings.map((o) =>
+              o.name === "UCI_LimitStrength" ? { ...o, value: e.target.checked } : o,
+            ),
+          }))
+            }
+          }}
+                                    />
+          {limitStrength && (
+            <h1> Can Limit Strength! </h1>
           )}
         </>
       )}

--- a/src/components/panels/analysis/EngineSettingsForm.tsx
+++ b/src/components/panels/analysis/EngineSettingsForm.tsx
@@ -10,7 +10,7 @@ import {
 import { IconPlayerStopFilled, IconSettings } from "@tabler/icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useAtomValue } from "jotai";
-import { memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { GoMode } from "@/bindings";
 import GoModeInput from "@/components/common/GoModeInput";

--- a/src/components/panels/analysis/EngineSettingsForm.tsx
+++ b/src/components/panels/analysis/EngineSettingsForm.tsx
@@ -50,8 +50,8 @@ function EngineSettingsForm({
   const { t } = useTranslation();
 
   const limitStrength = settings.settings.find((o) => o.name === "UCI_LimitStrength");
-  const maxElo = settings.settings.find((o) => o.name === "UCI_Elo")?.max
-  const minElo = settings.settings.find((o) => o.name === "UCI_Elo")?.min
+  const maxElo = settings.settings.find((o) => o.name === "UCI_Elo")?.max;
+  const minElo = settings.settings.find((o) => o.name === "UCI_Elo")?.min;
   const multipv = settings.settings.find((o) => o.name === "MultiPV");
   const threads = settings.settings.find((o) => o.name === "Threads");
   const hash = settings.settings.find((o) => o.name === "Hash");
@@ -134,30 +134,34 @@ function EngineSettingsForm({
               />
             </Group>
           )}
-          <Checkbox
-          label={"Adjust Engine rating"}
-          checked={Boolean(limitStrength?.value)}
-          onChange={(e) => {
-              setSettings((prev) => ({
-            ...prev,
-            settings: prev.settings.map((o) =>
-              o.name === "UCI_LimitStrength" ? { ...o, value: e.target.checked } : o,
-            ),
-          }))
-          }}
-                                    />
-          {limitStrength?.value && maxElo &&(
-            <EloSlider value={maxElo} minElo={Number(minElo)}
-                setValue={(v) =>
-                  setSettings((prev) => ({
-                    ...prev,
-                    settings: prev.settings.map((o) =>
-                      o.name === "UCI_Elo" ? { ...o, value: v || 1} : o,
-                    ),
-                  }))
-                }
-                color={color}
-              />
+          {limitStrength && (
+            <Checkbox
+              label={t("Engines.Settings.AdjustRating")}
+              checked={Boolean(limitStrength.value)}
+              onChange={(e) => {
+                setSettings((prev) => ({
+                  ...prev,
+                  settings: prev.settings.map((o) =>
+                    o.name === "UCI_LimitStrength" ? { ...o, value: e.target.checked } : o,
+                  ),
+                }));
+              }}
+            />
+          )}
+          {limitStrength?.value && maxElo && (
+            <EloSlider
+              value={maxElo}
+              minElo={Number(minElo)}
+              setValue={(v) =>
+                setSettings((prev) => ({
+                  ...prev,
+                  settings: prev.settings.map((o) =>
+                    o.name === "UCI_Elo" ? { ...o, value: v || 1 } : o,
+                  ),
+                }))
+              }
+              color={color}
+            />
           )}
         </>
       )}

--- a/src/translation/be-BY.json
+++ b/src/translation/be-BY.json
@@ -303,6 +303,7 @@
     "Engines.Remove.Message": "Вы ўпэўнены, што хочаце выдаліць гэты рухавік з En Croissant?",
     "Engines.Remove.Title": "Выдаліць рухавік",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Пашыраныя налады",
     "Engines.Settings.EditJSON": "Рэдагаваць JSON",
     "Engines.Settings.NoEngine": "Рухавік не абраны",

--- a/src/translation/be-BY.json
+++ b/src/translation/be-BY.json
@@ -301,6 +301,7 @@
     "Engines.Remove.Message": "Вы ўпэўнены, што хочаце выдаліць гэты рухавік з En Croissant?",
     "Engines.Remove.Title": "Выдаліць рухавік",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Пашыраныя налады",
     "Engines.Settings.EditJSON": "Рэдагаваць JSON",
     "Engines.Settings.NoEngine": "Рухавік не абраны",

--- a/src/translation/de-DE.json
+++ b/src/translation/de-DE.json
@@ -297,6 +297,7 @@
     "Engines.Remove.Message": "Bist du sicher, dass du diese Engine aus En Croissant entfernen möchtest?",
     "Engines.Remove.Title": "Engine entfernen",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Erweiterte Einstellungen",
     "Engines.Settings.EditJSON": "JSON bearbeiten",
     "Engines.Settings.NoEngine": "Keine Engine ausgewählt",

--- a/src/translation/de-DE.json
+++ b/src/translation/de-DE.json
@@ -299,6 +299,7 @@
     "Engines.Remove.Message": "Bist du sicher, dass du diese Engine aus En Croissant entfernen möchtest?",
     "Engines.Remove.Title": "Engine entfernen",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Erweiterte Einstellungen",
     "Engines.Settings.EditJSON": "JSON bearbeiten",
     "Engines.Settings.NoEngine": "Keine Engine ausgewählt",

--- a/src/translation/en-GB.json
+++ b/src/translation/en-GB.json
@@ -297,6 +297,7 @@
     "Engines.Remove.Message": "Are you sure you want to remove this engine from En Croissant?",
     "Engines.Remove.Title": "Remove Engine",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "Adjust Engine Rating",
     "Engines.Settings.AdvancedSettings": "Advanced settings",
     "Engines.Settings.EditJSON": "Edit JSON",
     "Engines.Settings.NoEngine": "No engine selected",

--- a/src/translation/en-GB.json
+++ b/src/translation/en-GB.json
@@ -299,6 +299,7 @@
     "Engines.Remove.Message": "Are you sure you want to remove this engine from En Croissant?",
     "Engines.Remove.Title": "Remove Engine",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "Adjust Engine Rating",
     "Engines.Settings.AdvancedSettings": "Advanced settings",
     "Engines.Settings.EditJSON": "Edit JSON",
     "Engines.Settings.NoEngine": "No engine selected",

--- a/src/translation/en-US.json
+++ b/src/translation/en-US.json
@@ -299,6 +299,7 @@
     "Engines.Remove.Message": "Are you sure you want to remove this engine from En Croissant?",
     "Engines.Remove.Title": "Remove Engine",
     "Engines.Selection.None": "No engines installed. Please <addEngineLink>Add an engine</addEngineLink> first.",
+    "Engines.Settings.AdjustRating": "Adjust Engine Rating",
     "Engines.Settings.AdvancedSettings": "Advanced settings",
     "Engines.Settings.EditJSON": "Edit JSON",
     "Engines.Settings.NoEngine": "No engine selected",

--- a/src/translation/en-US.json
+++ b/src/translation/en-US.json
@@ -297,6 +297,7 @@
     "Engines.Remove.Message": "Are you sure you want to remove this engine from En Croissant?",
     "Engines.Remove.Title": "Remove Engine",
     "Engines.Selection.None": "No engines installed. Please <addEngineLink>Add an engine</addEngineLink> first.",
+    "Engines.Settings.AdjustRating": "Adjust Engine Rating",
     "Engines.Settings.AdvancedSettings": "Advanced settings",
     "Engines.Settings.EditJSON": "Edit JSON",
     "Engines.Settings.NoEngine": "No engine selected",

--- a/src/translation/es-ES.json
+++ b/src/translation/es-ES.json
@@ -301,6 +301,7 @@
     "Engines.Remove.Message": "¿Está seguro de que desea eliminar este motor de En Croissant?",
     "Engines.Remove.Title": "Eliminar motor",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Configuración avanzada",
     "Engines.Settings.EditJSON": "Editar JSON",
     "Engines.Settings.NoEngine": "Ningún motor seleccionado",

--- a/src/translation/es-ES.json
+++ b/src/translation/es-ES.json
@@ -299,6 +299,7 @@
     "Engines.Remove.Message": "¿Está seguro de que desea eliminar este motor de En Croissant?",
     "Engines.Remove.Title": "Eliminar motor",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Configuración avanzada",
     "Engines.Settings.EditJSON": "Editar JSON",
     "Engines.Settings.NoEngine": "Ningún motor seleccionado",

--- a/src/translation/fr-FR.json
+++ b/src/translation/fr-FR.json
@@ -299,6 +299,7 @@
     "Engines.Remove.Message": "Êtes-vous sûr de vouloir supprimer le moteur ?",
     "Engines.Remove.Title": "Supprimer le moteur",
     "Engines.Selection.None": "Aucun moteur n'est installé. Veuillez d'abord <addEngineLink>ajouter un moteur</addEngineLink>.",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Paramètres avancés",
     "Engines.Settings.EditJSON": "Editer JSON",
     "Engines.Settings.NoEngine": "Aucun moteur sélectionné",

--- a/src/translation/fr-FR.json
+++ b/src/translation/fr-FR.json
@@ -301,6 +301,7 @@
     "Engines.Remove.Message": "Êtes-vous sûr de vouloir supprimer le moteur ?",
     "Engines.Remove.Title": "Supprimer le moteur",
     "Engines.Selection.None": "Aucun moteur n'est installé. Veuillez d'abord <addEngineLink>ajouter un moteur</addEngineLink>.",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Paramètres avancés",
     "Engines.Settings.EditJSON": "Editer JSON",
     "Engines.Settings.NoEngine": "Aucun moteur sélectionné",

--- a/src/translation/it-IT.json
+++ b/src/translation/it-IT.json
@@ -301,6 +301,7 @@
     "Engines.Remove.Message": "Sei sicuro di voler rimuovere questo motore da En Croissant?",
     "Engines.Remove.Title": "Rimuovi motore",
     "Engines.Selection.None": "Nessun motore installato. <addEngineLink>Aggiungi</addEngineLink> un motore.",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Impostazioni avanzate",
     "Engines.Settings.EditJSON": "Modifica JSON",
     "Engines.Settings.NoEngine": "Nessun motore selezionato",

--- a/src/translation/it-IT.json
+++ b/src/translation/it-IT.json
@@ -299,6 +299,7 @@
     "Engines.Remove.Message": "Sei sicuro di voler rimuovere questo motore da En Croissant?",
     "Engines.Remove.Title": "Rimuovi motore",
     "Engines.Selection.None": "Nessun motore installato. <addEngineLink>Aggiungi</addEngineLink> un motore.",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Impostazioni avanzate",
     "Engines.Settings.EditJSON": "Modifica JSON",
     "Engines.Settings.NoEngine": "Nessun motore selezionato",

--- a/src/translation/ko-KR.json
+++ b/src/translation/ko-KR.json
@@ -297,6 +297,7 @@
     "Engines.Remove.Message": "정말로 En Croissant에서 이 엔진을 제거하시겠습니까?",
     "Engines.Remove.Title": "엔진 제거",
     "Engines.Selection.None": "설치된 엔진이 없습니다. 먼저 <addEngineLink>엔진 추가</addEngineLink>를 눌러주세요.",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "고급 설정",
     "Engines.Settings.EditJSON": "JSON 편집",
     "Engines.Settings.NoEngine": "선택된 엔진 없음",

--- a/src/translation/ko-KR.json
+++ b/src/translation/ko-KR.json
@@ -295,6 +295,7 @@
     "Engines.Remove.Message": "정말로 En Croissant에서 이 엔진을 제거하시겠습니까?",
     "Engines.Remove.Title": "엔진 제거",
     "Engines.Selection.None": "설치된 엔진이 없습니다. 먼저 <addEngineLink>엔진 추가</addEngineLink>를 눌러주세요.",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "고급 설정",
     "Engines.Settings.EditJSON": "JSON 편집",
     "Engines.Settings.NoEngine": "선택된 엔진 없음",

--- a/src/translation/nb-NO.json
+++ b/src/translation/nb-NO.json
@@ -299,6 +299,7 @@
     "Engines.Remove.Message": "Er du sikker på at du vil fjerne denne computeren fra En Croissant?",
     "Engines.Remove.Title": "Fjern computer",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Avanserte innstillinger",
     "Engines.Settings.EditJSON": "Rediger JSON",
     "Engines.Settings.NoEngine": "Ingen computer valgt",

--- a/src/translation/nb-NO.json
+++ b/src/translation/nb-NO.json
@@ -297,6 +297,7 @@
     "Engines.Remove.Message": "Er du sikker på at du vil fjerne denne computeren fra En Croissant?",
     "Engines.Remove.Title": "Fjern computer",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Avanserte innstillinger",
     "Engines.Settings.EditJSON": "Rediger JSON",
     "Engines.Settings.NoEngine": "Ingen computer valgt",

--- a/src/translation/pl-PL.json
+++ b/src/translation/pl-PL.json
@@ -303,6 +303,7 @@
     "Engines.Remove.Message": "Czy na pewno chcesz usunąć ten silnik z En Croissant?",
     "Engines.Remove.Title": "Usuń silnik",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Zaawansowane ustawienia",
     "Engines.Settings.EditJSON": "Edytuj JSON",
     "Engines.Settings.NoEngine": "Nie wybrano silnika",

--- a/src/translation/pl-PL.json
+++ b/src/translation/pl-PL.json
@@ -301,6 +301,7 @@
     "Engines.Remove.Message": "Czy na pewno chcesz usunąć ten silnik z En Croissant?",
     "Engines.Remove.Title": "Usuń silnik",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Zaawansowane ustawienia",
     "Engines.Settings.EditJSON": "Edytuj JSON",
     "Engines.Settings.NoEngine": "Nie wybrano silnika",

--- a/src/translation/pt-PT.json
+++ b/src/translation/pt-PT.json
@@ -301,6 +301,7 @@
     "Engines.Remove.Message": "Tens a certeza que queres remover este engine do En Croissant?",
     "Engines.Remove.Title": "Remover Engine",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Configurações avançadas",
     "Engines.Settings.EditJSON": "Editar JSON",
     "Engines.Settings.NoEngine": "Nenhum engine selecionado",

--- a/src/translation/pt-PT.json
+++ b/src/translation/pt-PT.json
@@ -299,6 +299,7 @@
     "Engines.Remove.Message": "Tens a certeza que queres remover este engine do En Croissant?",
     "Engines.Remove.Title": "Remover Engine",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Configurações avançadas",
     "Engines.Settings.EditJSON": "Editar JSON",
     "Engines.Settings.NoEngine": "Nenhum engine selecionado",

--- a/src/translation/ru-RU.json
+++ b/src/translation/ru-RU.json
@@ -303,6 +303,7 @@
     "Engines.Remove.Message": "Вы уверены, что хотите удалить этот движок из En Croissant?",
     "Engines.Remove.Title": "Удалить движок",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Дополнительные настройки",
     "Engines.Settings.EditJSON": "Редактировать JSON",
     "Engines.Settings.NoEngine": "Движок не выбран",

--- a/src/translation/ru-RU.json
+++ b/src/translation/ru-RU.json
@@ -301,6 +301,7 @@
     "Engines.Remove.Message": "Вы уверены, что хотите удалить этот движок из En Croissant?",
     "Engines.Remove.Title": "Удалить движок",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Дополнительные настройки",
     "Engines.Settings.EditJSON": "Редактировать JSON",
     "Engines.Settings.NoEngine": "Движок не выбран",

--- a/src/translation/tr-TR.json
+++ b/src/translation/tr-TR.json
@@ -299,6 +299,7 @@
     "Engines.Remove.Message": "Bu motoru En Croissant'tan kaldırmak istediğinize emin misiniz?",
     "Engines.Remove.Title": "Motor Kaldır",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Gelişmiş ayarlar",
     "Engines.Settings.EditJSON": "JSON olarak düzenle",
     "Engines.Settings.NoEngine": "Hiçbir motor seçili değil",

--- a/src/translation/tr-TR.json
+++ b/src/translation/tr-TR.json
@@ -297,6 +297,7 @@
     "Engines.Remove.Message": "Bu motoru En Croissant'tan kaldırmak istediğinize emin misiniz?",
     "Engines.Remove.Title": "Motor Kaldır",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Gelişmiş ayarlar",
     "Engines.Settings.EditJSON": "JSON olarak düzenle",
     "Engines.Settings.NoEngine": "Hiçbir motor seçili değil",

--- a/src/translation/uk-UA.json
+++ b/src/translation/uk-UA.json
@@ -301,6 +301,7 @@
     "Engines.Remove.Message": "Ви впевнені, що хочете видалити цей движок із En Croissant?",
     "Engines.Remove.Title": "Видалити движок",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Додаткові налаштування",
     "Engines.Settings.EditJSON": "Редагувати JSON",
     "Engines.Settings.NoEngine": "Движок не вибрано",

--- a/src/translation/uk-UA.json
+++ b/src/translation/uk-UA.json
@@ -303,6 +303,7 @@
     "Engines.Remove.Message": "Ви впевнені, що хочете видалити цей движок із En Croissant?",
     "Engines.Remove.Title": "Видалити движок",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "Додаткові налаштування",
     "Engines.Settings.EditJSON": "Редагувати JSON",
     "Engines.Settings.NoEngine": "Движок не вибрано",

--- a/src/translation/zh-CN.json
+++ b/src/translation/zh-CN.json
@@ -299,6 +299,7 @@
     "Engines.Remove.Message": "您确定要从 En Croissant 中移除此引擎吗？",
     "Engines.Remove.Title": "移除引擎",
     "Engines.Selection.None": "未安装任何引擎，请先<addEngineLink>添加一个引擎</addEngineLink>！",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "高级设置",
     "Engines.Settings.EditJSON": "编辑 JSON",
     "Engines.Settings.NoEngine": "未选择引擎",

--- a/src/translation/zh-CN.json
+++ b/src/translation/zh-CN.json
@@ -297,6 +297,7 @@
     "Engines.Remove.Message": "您确定要从 En Croissant 中移除此引擎吗？",
     "Engines.Remove.Title": "移除引擎",
     "Engines.Selection.None": "未安装任何引擎，请先<addEngineLink>添加一个引擎</addEngineLink>！",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "高级设置",
     "Engines.Settings.EditJSON": "编辑 JSON",
     "Engines.Settings.NoEngine": "未选择引擎",

--- a/src/translation/zh-TW.json
+++ b/src/translation/zh-TW.json
@@ -297,6 +297,7 @@
     "Engines.Remove.Message": "您確定要從 En Croissant 中移除此引擎嗎？",
     "Engines.Remove.Title": "移除引擎",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "進階設定",
     "Engines.Settings.EditJSON": "編輯 JSON",
     "Engines.Settings.NoEngine": "未選取引擎",

--- a/src/translation/zh-TW.json
+++ b/src/translation/zh-TW.json
@@ -295,6 +295,7 @@
     "Engines.Remove.Message": "您確定要從 En Croissant 中移除此引擎嗎？",
     "Engines.Remove.Title": "移除引擎",
     "Engines.Selection.None": "",
+    "Engines.Settings.AdjustRating": "",
     "Engines.Settings.AdvancedSettings": "進階設定",
     "Engines.Settings.EditJSON": "編輯 JSON",
     "Engines.Settings.NoEngine": "未選取引擎",

--- a/src/utils/engines.ts
+++ b/src/utils/engines.ts
@@ -35,8 +35,8 @@ const engineSettingsSchema = z.array(
     z.object({
         name: z.string(),
         value: z.string().or(z.number()).or(z.boolean()).nullable(),
-        min: z.number().nullable(),
-        max: z.number().nullable(),
+        min: z.number().nullable().optional(),
+        max: z.number().nullable().optional(),
     }),
 );
 

--- a/src/utils/engines.ts
+++ b/src/utils/engines.ts
@@ -61,6 +61,7 @@ const remoteEngineSchema = z.object({
     loaded: z.boolean().nullish(),
     enabled: z.boolean().nullish(),
     go: goModeSchema.nullish(),
+    elo: z.number().nullish(),
     settings: engineSettingsSchema.nullish(),
 });
 

--- a/src/utils/engines.ts
+++ b/src/utils/engines.ts
@@ -5,7 +5,13 @@ import { z } from "zod";
 import { type BestMoves, commands, type EngineOptions, type GoMode } from "@/bindings";
 import { unwrap } from "./unwrap";
 
-export const requiredEngineSettings = ["MultiPV", "Threads", "Hash","UCI_LimitStrength","UCI_Elo"];
+export const requiredEngineSettings = [
+    "MultiPV",
+    "Threads",
+    "Hash",
+    "UCI_LimitStrength",
+    "UCI_Elo",
+];
 
 const goModeSchema: z.ZodSchema<GoMode> = z.union([
     z.object({
@@ -30,7 +36,7 @@ const engineSettingsSchema = z.array(
         name: z.string(),
         value: z.string().or(z.number()).or(z.boolean()).nullable(),
         min: z.number().nullable(),
-        max: z.number().nullable()
+        max: z.number().nullable(),
     }),
 );
 

--- a/src/utils/engines.ts
+++ b/src/utils/engines.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { type BestMoves, commands, type EngineOptions, type GoMode } from "@/bindings";
 import { unwrap } from "./unwrap";
 
-export const requiredEngineSettings = ["MultiPV", "Threads", "Hash"];
+export const requiredEngineSettings = ["MultiPV", "Threads", "Hash","UCI_LimitStrength","UCI_Elo"];
 
 const goModeSchema: z.ZodSchema<GoMode> = z.union([
     z.object({
@@ -29,6 +29,8 @@ const engineSettingsSchema = z.array(
     z.object({
         name: z.string(),
         value: z.string().or(z.number()).or(z.boolean()).nullable(),
+        min: z.number().nullable(),
+        max: z.number().nullable()
     }),
 );
 
@@ -61,7 +63,6 @@ const remoteEngineSchema = z.object({
     loaded: z.boolean().nullish(),
     enabled: z.boolean().nullish(),
     go: goModeSchema.nullish(),
-    elo: z.number().nullish(),
     settings: engineSettingsSchema.nullish(),
 });
 


### PR DESCRIPTION
This allows users to adjust the strength of the Opponent Engine using the UCI_LimitStrength and UCI_Elo attributes. 

If the engine allows these options (currently only Stockfish does from the default engines) the user is shown a checkbox labelled "Adjust Engine Rating". When clicked, a slider appears which allows the user to set a rating between the min/max UCI_Elo attributes.

EnginesSelect has a useEffect that will update the engines.json with the new options if an engine supports them. This is to avoid the user having to remove and re-download the engine to get the new options.

Partly closes #558 