### PR TITLE
typo fixed that caused tournament selection UI break

### DIFF
--- a/src/components/databases/TournamentTable.tsx
+++ b/src/components/databases/TournamentTable.tsx
@@ -19,9 +19,9 @@ function TournamentTable() {
 
   const file = useStore(store, (s) => s.database?.file)!;
   const query = useStore(store, (s) => s.tournaments.query);
-  const selected = useStore(store, (s) => s.tournaments.selectedTournamet);
+  const selected = useStore(store, (s) => s.tournaments.selectedTournament);
   const setQuery = useStore(store, (s) => s.setTournamentsQuery);
-  const setSelected = useStore(store, (s) => s.setTournamentsSelectedTournamet);
+  const setSelected = useStore(store, (s) => s.setTournamentsselectedTournament);
 
   const { data, error, isLoading } = useSWR(["tournaments", file, query], () =>
     commands.getTournaments(file, query).then(unwrap),

--- a/src/components/databases/TournamentTable.tsx
+++ b/src/components/databases/TournamentTable.tsx
@@ -19,9 +19,9 @@ function TournamentTable() {
 
   const file = useStore(store, (s) => s.database?.file)!;
   const query = useStore(store, (s) => s.tournaments.query);
-  const selected = useStore(store, (s) => s.tournaments.selectedTournament);
+  const selected = useStore(store, (s) => s.tournaments.SelectedTournament);
   const setQuery = useStore(store, (s) => s.setTournamentsQuery);
-  const setSelected = useStore(store, (s) => s.setTournamentsselectedTournament);
+  const setSelected = useStore(store, (s) => s.setTournamentsSelectedTournament);
 
   const { data, error, isLoading } = useSWR(["tournaments", file, query], () =>
     commands.getTournaments(file, query).then(unwrap),

--- a/src/state/store/database.ts
+++ b/src/state/store/database.ts
@@ -36,7 +36,7 @@ export interface DatabaseViewStore {
     setPlayersActiveTab: (value: DatabaseViewStore["players"]["activeTab"]) => void;
 
     setTournamentsQuery: (query: TournamentQuery) => void;
-    setTournamentsselectedTournament: (tournament?: number) => void;
+  setTournamentsSelectedTournament: (tournament?: number) => void;
     setTournamentsActiveTab: (value: DatabaseViewStore["tournaments"]["activeTab"]) => void;
 }
 
@@ -177,7 +177,7 @@ export const activeDatabaseViewStore = createStore<DatabaseViewStore>()(
                     }),
                 );
             },
-            setTournamentsselectedTournament: (tournament?: number) => {
+          setTournamentsSelectedTournament: (tournament?: number) => {
                 set(
                     produce((state: Draft<DatabaseViewStore>) => {
                         state.tournaments.selectedTournament = tournament;

--- a/src/state/store/database.ts
+++ b/src/state/store/database.ts
@@ -19,7 +19,7 @@ export interface DatabaseViewStore {
     };
     tournaments: {
         query: TournamentQuery;
-        selectedTournament?: number;
+        SelectedTournament?: number;
         activeTab: "games" | "leaderboard";
     };
 
@@ -180,7 +180,7 @@ export const activeDatabaseViewStore = createStore<DatabaseViewStore>()(
           setTournamentsSelectedTournament: (tournament?: number) => {
                 set(
                     produce((state: Draft<DatabaseViewStore>) => {
-                        state.tournaments.selectedTournament = tournament;
+                        state.tournaments.SelectedTournament = tournament;
                     }),
                 );
             },

--- a/src/state/store/database.ts
+++ b/src/state/store/database.ts
@@ -19,7 +19,7 @@ export interface DatabaseViewStore {
     };
     tournaments: {
         query: TournamentQuery;
-        selectedTournamet?: number;
+        selectedTournament?: number;
         activeTab: "games" | "leaderboard";
     };
 
@@ -36,7 +36,7 @@ export interface DatabaseViewStore {
     setPlayersActiveTab: (value: DatabaseViewStore["players"]["activeTab"]) => void;
 
     setTournamentsQuery: (query: TournamentQuery) => void;
-    setTournamentsSelectedTournamet: (tournament?: number) => void;
+    setTournamentsselectedTournament: (tournament?: number) => void;
     setTournamentsActiveTab: (value: DatabaseViewStore["tournaments"]["activeTab"]) => void;
 }
 
@@ -177,10 +177,10 @@ export const activeDatabaseViewStore = createStore<DatabaseViewStore>()(
                     }),
                 );
             },
-            setTournamentsSelectedTournamet: (tournament?: number) => {
+            setTournamentsselectedTournament: (tournament?: number) => {
                 set(
                     produce((state: Draft<DatabaseViewStore>) => {
-                        state.tournaments.selectedTournamet = tournament;
+                        state.tournaments.selectedTournament = tournament;
                     }),
                 );
             },


### PR DESCRIPTION
two files :

src\components\databases\TournamentTable.tsx (2 occurrences)

src\state\store\database.ts (4 occurrences)

these had a typo error that misspelled selectedTournament as selectedTournamet total 6 typo occurences were fixed.