### PR TITLE
fix eval bar flicker while browsing moves

### DIFF
--- a/src/components/boards/Board.tsx
+++ b/src/components/boards/Board.tsx
@@ -15,7 +15,7 @@ import { chessgroundDests, chessgroundMove } from "chessops/compat";
 import { makeFen, parseFen } from "chessops/fen";
 import { makeSan } from "chessops/san";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { memo, useCallback, useContext, useMemo, useState } from "react";
+import { memo, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useTranslation } from "react-i18next";
 import { match } from "ts-pattern";
@@ -103,12 +103,22 @@ function Board({
 
   const root = useStore(store, (s) => s.root);
   const rootFen = useStore(store, (s) => s.root.fen);
+  const position = useStore(store, (s) => s.position);
   const moves = useStore(
     store,
     useShallow((s) => getVariationLine(s.root, s.position)),
   );
   const headers = useStore(store, (s) => s.headers);
   const currentNode = useStore(store, (s) => s.currentNode());
+  const [displayedScore, setDisplayedScore] = useState(currentNode.score || null);
+
+  useEffect(() => {
+    if (currentNode.score) {
+      setDisplayedScore(currentNode.score);
+    } else if (position.length === 0) {
+      setDisplayedScore(null);
+    }
+  }, [currentNode.score, position.length]);
 
   const arrows = useAtomValue(
     bestMovesFamily({
@@ -461,7 +471,7 @@ function Board({
                   </ActionIcon>
                 </Center>
               )}
-              {evalOpen && <EvalBar score={currentNode.score || null} orientation={orientation} />}
+              {evalOpen && <EvalBar score={displayedScore} orientation={orientation} />}
             </Box>
             <Box
               style={

--- a/src/components/boards/EvalListener.tsx
+++ b/src/components/boards/EvalListener.tsx
@@ -34,13 +34,14 @@ function EvalListener() {
   const threat = useAtomValue(currentThreatAtom);
   const store = useContext(TreeStateContext)!;
   const fen = useStore(store, (s) => s.root.fen);
+  const targetPath = useStore(store, (s) => s.position);
 
   const moves = useStore(
     store,
     useShallow((s) => getVariationLine(s.root, s.position)),
   );
 
-  const [pos, error] = positionFromFen(fen);
+  const [pos] = positionFromFen(fen);
   if (pos) {
     for (const uci of moves) {
       const move = parseUci(uci);
@@ -91,6 +92,7 @@ function EvalListener() {
         fen={fen}
         moves={moves}
         threat={threat}
+        targetPath={targetPath}
       />
     ));
 }
@@ -105,6 +107,7 @@ function EngineListener({
   fen,
   moves,
   threat,
+  targetPath,
 }: {
   engine: Engine;
   firstEngineWithLines: string | null;
@@ -115,10 +118,12 @@ function EngineListener({
   fen: string;
   moves: string[];
   threat: boolean;
+  targetPath: number[];
 }) {
   const store = useContext(TreeStateContext)!;
-  const setScore = useStore(store, (s) => s.setScore);
+  const setScoreAtPath = useStore(store, (s) => s.setScoreAtPath);
   const activeTab = useAtomValue(activeTabAtom);
+  const searchingMovesKey = useMemo(() => searchingMoves.join(","), [searchingMoves]);
 
   const [, setProgress] = useAtom(engineProgressFamily({ engine: engine.id, tab: activeTab! }));
 
@@ -146,7 +151,7 @@ function EngineListener({
         startTransition(() => {
           setEngineVariation((prev) => {
             const newMap = new Map(prev);
-            newMap.set(`${searchingFen}:${searchingMoves.join(",")}`, ev);
+            newMap.set(`${searchingFen}:${searchingMovesKey}`, ev);
             if (threat) {
               newMap.delete(`${fen}:${moves.join(",")}`);
             } else if (finalFen) {
@@ -158,7 +163,7 @@ function EngineListener({
           const shouldSetScore =
             firstEngineWithLines === engine.id || firstEngineWithLines === null;
           if (shouldSetScore) {
-            setScore(ev[0].score);
+            setScoreAtPath(targetPath, ev[0].score);
           }
         });
       }
@@ -168,14 +173,21 @@ function EngineListener({
     };
   }, [
     activeTab,
-    setScore,
+    setScoreAtPath,
+    setProgress,
     settings.enabled,
     isGameOver,
     searchingFen,
-    JSON.stringify(searchingMoves),
+    searchingMoves,
+    searchingMovesKey,
+    threat,
+    fen,
+    moves,
+    finalFen,
     engine.id,
     setEngineVariation,
     firstEngineWithLines,
+    targetPath,
   ]);
 
   const getBestMoves = useMemo(
@@ -189,7 +201,7 @@ function EngineListener({
         .with("chessdb", () => chessdbGetBestMoves)
         .with("lichess", () => lichessGetBestMoves)
         .exhaustive(),
-    [engine.type, engine],
+    [engine],
   );
 
   useThrottledEffect(
@@ -214,7 +226,7 @@ function EngineListener({
               const [progress, bestMoves] = moves;
               setEngineVariation((prev) => {
                 const newMap = new Map(prev);
-                newMap.set(`${searchingFen}:${searchingMoves.join(",")}`, bestMoves);
+                newMap.set(`${searchingFen}:${searchingMovesKey}`, bestMoves);
                 return newMap;
               });
               setProgress(progress);
@@ -233,7 +245,7 @@ function EngineListener({
       JSON.stringify(settings.settings),
       settings.go,
       searchingFen,
-      JSON.stringify(searchingMoves),
+      searchingMovesKey,
       isGameOver,
       activeTab,
       getBestMoves,

--- a/src/state/store/tree.ts
+++ b/src/state/store/tree.ts
@@ -18,10 +18,18 @@ import {
     defaultTree,
     type GameHeaders,
     getNodeAtPath,
+    getNodeAtPathOrNull,
     type TreeNode,
     type TreeState,
     treeIteratorMainLine,
 } from "@/utils/treeReducer";
+
+function setNodeScore(state: Draft<TreeStoreState>, path: number[], score: Score) {
+    const node = getNodeAtPathOrNull(state.root, path);
+    if (!node) return;
+    state.dirty = true;
+    node.score = score;
+}
 
 export interface TreeStoreState extends TreeState {
     currentNode: () => TreeNode;
@@ -66,6 +74,7 @@ export interface TreeStoreState extends TreeState {
     setResult: (payload: Outcome) => void;
     setShapes: (shapes: DrawShape[]) => void;
     setScore: (score: Score) => void;
+    setScoreAtPath: (path: number[], score: Score) => void;
 
     clearShapes: () => void;
 
@@ -478,11 +487,13 @@ export const createTreeStore = (id?: string, initialTree?: TreeState) => {
         setScore: (score) =>
             set(
                 produce((state) => {
-                    state.dirty = true;
-                    const node = getNodeAtPath(state.root, state.position);
-                    if (node) {
-                        node.score = score;
-                    }
+                    setNodeScore(state, state.position, score);
+                }),
+            ),
+        setScoreAtPath: (path, score) =>
+            set(
+                produce((state) => {
+                    setNodeScore(state, path, score);
                 }),
             ),
         addAnalysis: (analysis, options) =>

--- a/src/utils/tests/store.test.ts
+++ b/src/utils/tests/store.test.ts
@@ -380,6 +380,51 @@ test("should handle setScore", () => {
     });
 });
 
+test("should handle setScoreAtPath", () => {
+    store.setState(treeE4D5());
+    store.getState().setScoreAtPath([0], {
+        value: {
+            type: "cp",
+            value: 42,
+        },
+        wdl: null,
+    });
+
+    expect(getNewState()).toStrictEqual({
+        ...treeE4D5(),
+        dirty: true,
+        position: [0, 0],
+        root: {
+            ...treeE4D5().root,
+            children: [
+                {
+                    ...treeE4D5().root.children[0],
+                    score: {
+                        value: {
+                            type: "cp",
+                            value: 42,
+                        },
+                        wdl: null,
+                    },
+                },
+            ],
+        },
+    });
+});
+
+test("should ignore invalid setScoreAtPath", () => {
+    store.setState(treeE4D5());
+    store.getState().setScoreAtPath([1], {
+        value: {
+            type: "cp",
+            value: 42,
+        },
+        wdl: null,
+    });
+
+    expect(getNewState()).toStrictEqual(treeE4D5());
+});
+
 test("should handle setShapes", () => {
     store.setState({ ...treeE4D5(), position: [0] });
     store.getState().setShapes([

--- a/src/utils/treeReducer.ts
+++ b/src/utils/treeReducer.ts
@@ -169,15 +169,19 @@ export function getGameName(headers: GameHeaders) {
     return "Unknown";
 }
 
-export const getNodeAtPath = (node: TreeNode, path: number[]): TreeNode => {
+export const getNodeAtPathOrNull = (node: TreeNode, path: number[]): TreeNode | null => {
     let currentNode = node;
     for (const index of path) {
         if (!currentNode.children || index >= currentNode.children.length) {
-            return currentNode;
+            return null;
         }
         currentNode = currentNode.children[index];
     }
     return currentNode;
+};
+
+export const getNodeAtPath = (node: TreeNode, path: number[]): TreeNode => {
+    return getNodeAtPathOrNull(node, path) ?? node;
 };
 
 export function getTreeStructureHash(node: TreeNode): string {


### PR DESCRIPTION
- keep the eval bar from blanking while the next move's eval is still loading
- write live engine scores to the searched move path instead of the currently selected node