### PR TITLE
improve nodes decimals

### DIFF
--- a/src/components/panels/analysis/BestMoves.tsx
+++ b/src/components/panels/analysis/BestMoves.tsx
@@ -340,8 +340,8 @@ function EngineTop({
   const { t } = useTranslation();
   const isComputed = engineVariations && engineVariations.length > 0;
   const depth = isComputed ? engineVariations[0].depth : 0;
-  const nodes = isComputed ? formatNodes(engineVariations[0].nodes) : 0;
-  const nps = isComputed ? formatNodes(engineVariations[0].nps) : 0;
+  const nodes = isComputed ? formatNodes(engineVariations[0].nodes, 2) : 0;
+  const nps = isComputed ? formatNodes(engineVariations[0].nps, 1) : 0;
 
   return (
     <Group justify="space-between" wrap="nowrap">

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -66,7 +66,7 @@ export function formatThemeLabel(theme: string) {
         .join(" ");
 }
 
-export function formatNodes(nodes: number) {
+export function formatNodes(nodes: number, decimals = 0) {
     const units = ["", "k", "M", "B", "T"];
     let i = 0;
     let value = nodes;
@@ -76,7 +76,7 @@ export function formatNodes(nodes: number) {
         i++;
     }
 
-    return `${value.toFixed(0)}${units[i]}`;
+    return `${value.toFixed(decimals)}${units[i]}`;
 }
 
 export function formatTime(ms: number) {


### PR DESCRIPTION
previously large node counts likes 1B always stayed at 1B until the second billion is reached, this makes the node count progress feel a bit stuck.. 
this changes the nps to include 1 decimal place and the node count 2..