### PR TITLE
Add auto-start engines option when entering analysis board

### DIFF
--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -34,6 +34,7 @@ import posthog from "posthog-js";
 import { useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  autoStartAnalysisEnginesAtom,
   autoPromoteAtom,
   autoSaveAtom,
   enableBoardScrollAtom,
@@ -311,6 +312,14 @@ export default function Page() {
         description: t("Settings.AutoSave.Desc"),
         keywords: ["save", "auto"],
         render: () => <SettingsSwitch atom={autoSaveAtom} />,
+      },
+      {
+        id: "auto-start-engine-on-board-enter",
+        category: "board",
+        title: t("Settings.AutoStartEngineOnBoardEnter"),
+        description: t("Settings.AutoStartEngineOnBoardEnter.Desc"),
+        keywords: ["engine", "analysis", "auto", "start", "board", "enter"],
+        render: () => <SettingsSwitch atom={autoStartAnalysisEnginesAtom} />,
       },
       {
         id: "preview-board",

--- a/src/components/tabs/BoardsPage.tsx
+++ b/src/components/tabs/BoardsPage.tsx
@@ -2,13 +2,19 @@ import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd";
 import { ActionIcon, ScrollArea, Tabs } from "@mantine/core";
 import { useHotkeys, useToggle } from "@mantine/hooks";
 import { IconPlus } from "@tabler/icons-react";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { type ReactNode, startTransition, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Mosaic, type MosaicNode } from "react-mosaic-component";
 import { match } from "ts-pattern";
 import { commands } from "@/bindings";
-import { activeTabAtom, tabsAtom } from "@/state/atoms";
+import {
+  activeTabAtom,
+  autoStartAnalysisEnginesAtom,
+  enableAllAtom,
+  enginesAtom,
+  tabsAtom,
+} from "@/state/atoms";
 import { keyMapAtom } from "@/state/keybinds";
 import { createTab, genID, isPersistentGameOrigin, type Tab } from "@/utils/tabs";
 import { unwrap } from "@/utils/unwrap";
@@ -288,6 +294,23 @@ const windowsStateAtom = atomWithStorage<WindowsState>("windowsState", {
   },
 });
 
+function AutoStartAnalysisEngines() {
+  const autoStartAnalysisEngines = useAtomValue(autoStartAnalysisEnginesAtom);
+  const engines = useAtomValue(enginesAtom);
+  const enableAll = useSetAtom(enableAllAtom);
+  const loadedEngineCount = (engines ?? []).filter((engine) => engine.loaded).length;
+
+  useEffect(() => {
+    if (!autoStartAnalysisEngines || loadedEngineCount === 0) {
+      return;
+    }
+
+    enableAll(true);
+  }, [autoStartAnalysisEngines, loadedEngineCount, enableAll]);
+
+  return null;
+}
+
 function TabSwitch({
   tab,
   saveModalOpened,
@@ -324,6 +347,7 @@ function TabSwitch({
           onChange={(currentNode) => setWindowsState({ currentNode })}
           resize={{ minimumPaneSizePercentage: 0 }}
         />
+        <AutoStartAnalysisEngines />
         <BoardAnalysis />
         <ConfirmChangesModal
           opened={saveModalOpened}

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -183,6 +183,10 @@ export const eraseDrawablesOnClickAtom = atomWithStorage<boolean>(
 );
 export const autoPromoteAtom = atomWithStorage<boolean>("auto-promote", true);
 export const autoSaveAtom = atomWithStorage<boolean>("auto-save", true);
+export const autoStartAnalysisEnginesAtom = atomWithStorage<boolean>(
+    "auto-start-analysis-engines",
+    false,
+);
 export const previewBoardOnHoverAtom = atomWithStorage<boolean>("preview-board-on-hover", true);
 export const flipBoardAfterMoveAtom = atomWithStorage<boolean>("flip-board-after-move", true);
 export const enableBoardScrollAtom = atomWithStorage<boolean>("board-scroll", true);

--- a/src/translation/be-BY.json
+++ b/src/translation/be-BY.json
@@ -510,6 +510,8 @@
     "Settings.AutoPromition.Desc": "Аўтаматычна павышаць да каралевы",
     "Settings.AutoSave": "Аўтазахаванне",
     "Settings.AutoSave.Desc": "Аўтаматычна захоўваць пасля кожнага ходу",
+    "Settings.AutoStartEngineOnBoardEnter": "",
+    "Settings.AutoStartEngineOnBoardEnter.Desc": "",
     "Settings.Board": "Дошка",
     "Settings.Board.Desc": "Наладзіць дошку аналізу і элементы кіравання гульнёй",
     "Settings.ConsecutiveArrows": "Паслядоўныя стрэлкі",

--- a/src/translation/de-DE.json
+++ b/src/translation/de-DE.json
@@ -504,6 +504,8 @@
     "Settings.AutoPromition.Desc": "Automatisch in eine Dame umwandeln, wenn ein Bauer die letzte Reihe erreicht",
     "Settings.AutoSave": "Automatisches Speichern",
     "Settings.AutoSave.Desc": "Speichere nach jedem Zug automatisch in eine Datei",
+    "Settings.AutoStartEngineOnBoardEnter": "",
+    "Settings.AutoStartEngineOnBoardEnter.Desc": "",
     "Settings.Board": "Brett",
     "Settings.Board.Desc": "Passe das Analysebrett und die Spielsteuerung an",
     "Settings.ConsecutiveArrows": "Folgepfeile",

--- a/src/translation/en-GB.json
+++ b/src/translation/en-GB.json
@@ -518,6 +518,8 @@
     "Settings.AutoPromition.Desc": "Automatically promote to a queen when a pawn reaches the last rank",
     "Settings.AutoSave": "Auto Save",
     "Settings.AutoSave.Desc": "Auto save to file after each move",
+    "Settings.AutoStartEngineOnBoardEnter": "",
+    "Settings.AutoStartEngineOnBoardEnter.Desc": "",
     "Settings.Board": "Board",
     "Settings.Board.Desc": "Customise the analysis board and game controls",
     "Settings.ConsecutiveArrows": "Consecutive Arrows",

--- a/src/translation/en-US.json
+++ b/src/translation/en-US.json
@@ -518,6 +518,8 @@
     "Settings.AutoPromition.Desc": "Automatically promote to a queen when a pawn reaches the last rank",
     "Settings.AutoSave": "Auto Save",
     "Settings.AutoSave.Desc": "Auto save to file after each move",
+    "Settings.AutoStartEngineOnBoardEnter": "Auto-start Engines On Analysis Board Entry",
+    "Settings.AutoStartEngineOnBoardEnter.Desc": "Automatically start all loaded engines when entering an analysis board",
     "Settings.Board": "Board",
     "Settings.Board.Desc": "Customize the analysis board and game controls",
     "Settings.ConsecutiveArrows": "Consecutive Arrows",

--- a/src/translation/es-ES.json
+++ b/src/translation/es-ES.json
@@ -507,6 +507,8 @@
     "Settings.AutoPromition.Desc": "Promocionar automáticamente a reina",
     "Settings.AutoSave": "Guardar automáticamente",
     "Settings.AutoSave.Desc": "Guardar automáticamente después de cada movimiento",
+    "Settings.AutoStartEngineOnBoardEnter": "",
+    "Settings.AutoStartEngineOnBoardEnter.Desc": "",
     "Settings.Board": "Tablero",
     "Settings.Board.Desc": "Personalizar el tablero de análisis y los controles de la partida",
     "Settings.ConsecutiveArrows": "Flechas consecutivas",

--- a/src/translation/fr-FR.json
+++ b/src/translation/fr-FR.json
@@ -521,6 +521,8 @@
     "Settings.AutoPromition.Desc": "Promotion en Dame automatique lorsqu'un pion est éligible",
     "Settings.AutoSave": "Sauvegarde automatique",
     "Settings.AutoSave.Desc": "Sauvegarde la partie automatiquement après chaque coup",
+    "Settings.AutoStartEngineOnBoardEnter": "",
+    "Settings.AutoStartEngineOnBoardEnter.Desc": "",
     "Settings.Board": "Échiquier",
     "Settings.Board.Desc": "Personnaliser l'échiquier d'analyse et les contrôles",
     "Settings.ConsecutiveArrows": "Flèches successives",

--- a/src/translation/it-IT.json
+++ b/src/translation/it-IT.json
@@ -507,6 +507,8 @@
     "Settings.AutoPromition.Desc": "Promuove automaticamente a donna quando un pedone raggiunge l'ultima traversa",
     "Settings.AutoSave": "Salvataggio automatico",
     "Settings.AutoSave.Desc": "Salva automaticamente il file dopo ogni mossa",
+    "Settings.AutoStartEngineOnBoardEnter": "",
+    "Settings.AutoStartEngineOnBoardEnter.Desc": "",
     "Settings.Board": "Scacchiera",
     "Settings.Board.Desc": "Personalizza la scacchiera di analisi e i controlli di gioco",
     "Settings.ConsecutiveArrows": "Frecce consecutive",

--- a/src/translation/ko-KR.json
+++ b/src/translation/ko-KR.json
@@ -516,6 +516,8 @@
     "Settings.AutoPromition.Desc": "폰이 마지막 랭크에 도달했을 때 퀸으로 자동 승진합니다",
     "Settings.AutoSave": "자동 저장",
     "Settings.AutoSave.Desc": "수를 두고 나면 파일로 자동 저장합니다",
+    "Settings.AutoStartEngineOnBoardEnter": "분석 보드 진입 시 엔진 자동 실행",
+    "Settings.AutoStartEngineOnBoardEnter.Desc": "분석 보드에 들어갈 때 로드된 모든 엔진을 자동으로 시작합니다",
     "Settings.Board": "보드",
     "Settings.Board.Desc": "분석 보드와 조작 방식을 설정합니다",
     "Settings.ConsecutiveArrows": "연속 화살표",

--- a/src/translation/nb-NO.json
+++ b/src/translation/nb-NO.json
@@ -504,6 +504,8 @@
     "Settings.AutoPromition.Desc": "Bonden blir til en dronning når den kommer til siste rad.",
     "Settings.AutoSave": "Lagre automatisk",
     "Settings.AutoSave.Desc": "Lagre til filen etter hvert trekk",
+    "Settings.AutoStartEngineOnBoardEnter": "",
+    "Settings.AutoStartEngineOnBoardEnter.Desc": "",
     "Settings.Board": "Brett",
     "Settings.Board.Desc": "Tilpass analysebrett",
     "Settings.ConsecutiveArrows": "Konskutive Piler",

--- a/src/translation/pl-PL.json
+++ b/src/translation/pl-PL.json
@@ -510,6 +510,8 @@
     "Settings.AutoPromition.Desc": "Automatycznie promuj na hetmana, gdy pionek dotrze do ostatniego rzędu",
     "Settings.AutoSave": "Automatyczne zapisywanie",
     "Settings.AutoSave.Desc": "Automatycznie zapisuj do pliku po każdym ruchu",
+    "Settings.AutoStartEngineOnBoardEnter": "",
+    "Settings.AutoStartEngineOnBoardEnter.Desc": "",
     "Settings.Board": "Szachownica",
     "Settings.Board.Desc": "Dostosuj tablicę analizy i sterowanie grą",
     "Settings.ConsecutiveArrows": "Kolejne strzałki",

--- a/src/translation/pt-PT.json
+++ b/src/translation/pt-PT.json
@@ -507,6 +507,8 @@
     "Settings.AutoPromition.Desc": "Automaticamente promover para rainha",
     "Settings.AutoSave": "Gravar automaticamente",
     "Settings.AutoSave.Desc": "Grava automaticamente após cada jogada",
+    "Settings.AutoStartEngineOnBoardEnter": "",
+    "Settings.AutoStartEngineOnBoardEnter.Desc": "",
     "Settings.Board": "Tabuleiro",
     "Settings.Board.Desc": "Customizar o tabuleiro de análise e controlos de jogo",
     "Settings.ConsecutiveArrows": "Setas consecutivas",

--- a/src/translation/ru-RU.json
+++ b/src/translation/ru-RU.json
@@ -524,6 +524,8 @@
     "Settings.AutoPromition.Desc": "Автоматически продвигать до ферзя",
     "Settings.AutoSave": "Автосохранение",
     "Settings.AutoSave.Desc": "Автоматически сохранять после каждого хода",
+    "Settings.AutoStartEngineOnBoardEnter": "",
+    "Settings.AutoStartEngineOnBoardEnter.Desc": "",
     "Settings.Board": "Доска",
     "Settings.Board.Desc": "Настроить доску анализа и игровые элементы управления",
     "Settings.ConsecutiveArrows": "Последовательные стрелки",

--- a/src/translation/tr-TR.json
+++ b/src/translation/tr-TR.json
@@ -504,6 +504,8 @@
     "Settings.AutoPromition.Desc": "Piyon son yataya eriştiğinde otomatik olarak vezire terfi et",
     "Settings.AutoSave": "Otomatik Kaydet",
     "Settings.AutoSave.Desc": "Her hamle sonrası otomatik olarak dosyaya kaydet",
+    "Settings.AutoStartEngineOnBoardEnter": "",
+    "Settings.AutoStartEngineOnBoardEnter.Desc": "",
     "Settings.Board": "Tahta",
     "Settings.Board.Desc": "Analiz tahtasını ve oyun kontrollerini düzenleyin",
     "Settings.ConsecutiveArrows": "Ardışık Oklar",

--- a/src/translation/uk-UA.json
+++ b/src/translation/uk-UA.json
@@ -510,6 +510,8 @@
     "Settings.AutoPromition.Desc": "Автоматично підвищувати до ферзя",
     "Settings.AutoSave": "Автозбереження",
     "Settings.AutoSave.Desc": "Автоматично зберігати після кожного ходу",
+    "Settings.AutoStartEngineOnBoardEnter": "",
+    "Settings.AutoStartEngineOnBoardEnter.Desc": "",
     "Settings.Board": "Дошка",
     "Settings.Board.Desc": "Налаштувати дошку аналізу та елементи керування грою",
     "Settings.ConsecutiveArrows": "Послідовні стрілки",

--- a/src/translation/zh-CN.json
+++ b/src/translation/zh-CN.json
@@ -518,6 +518,8 @@
     "Settings.AutoPromition.Desc": "当兵到达底线时，自动升变为后",
     "Settings.AutoSave": "自动保存",
     "Settings.AutoSave.Desc": "每步棋后自动保存到文件",
+    "Settings.AutoStartEngineOnBoardEnter": "",
+    "Settings.AutoStartEngineOnBoardEnter.Desc": "",
     "Settings.Board": "棋盘",
     "Settings.Board.Desc": "自定义分析棋盘与对局控制",
     "Settings.ConsecutiveArrows": "连续箭头",

--- a/src/translation/zh-TW.json
+++ b/src/translation/zh-TW.json
@@ -502,6 +502,8 @@
     "Settings.AutoPromition.Desc": "當兵到達底線時自動升變為后",
     "Settings.AutoSave": "自動儲存",
     "Settings.AutoSave.Desc": "每步棋後自動儲存檔案",
+    "Settings.AutoStartEngineOnBoardEnter": "",
+    "Settings.AutoStartEngineOnBoardEnter.Desc": "",
     "Settings.Board": "棋盤",
     "Settings.Board.Desc": "自訂分析棋盤與對局控制",
     "Settings.ConsecutiveArrows": "連續箭頭",


### PR DESCRIPTION
## Summary
This PR adds an option to automatically start all loaded engines when entering an analysis board.

Closes #495

## What changed
- Added an "Auto-start Engines on Analysis Board Entry" toggle to the Board section in Settings
- Set the option to off by default so the existing behavior remains unchanged unless users opt in
- Persisted the toggle state
- Automatically starts all loaded engines when the option is enabled and an analysis board is opened, including when switching to an analysis board from other tabs/entry points
- Does nothing when there are no loaded engines
- Added translation keys for the new setting across locales, with en-US and ko-KR values provided

## Note
Thanks for building and maintaining this great project.
I also found this feature useful in day-to-day usage, so I’m happy to contribute it.