### PR TITLE
add blue4 board theme

### DIFF
--- a/public/board/blue4.svg
+++ b/public/board/blue4.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:x="http://www.w3.org/1999/xlink" viewBox="0 0 8 8" shape-rendering="crispEdges">
+<g id="a">
+  <g id="b">
+    <g id="c">
+      <g id="d">
+        <rect width="1" height="1" fill="#e9e9d1" id="e"/>
+        <use x="1" y="1" href="#e" x:href="#e"/>
+        <rect y="1" width="1" height="1" fill="#4e7293" id="f"/>
+        <use x="1" y="-1" href="#f" x:href="#f"/>
+      </g>
+      <use x="2" href="#d" x:href="#d"/>
+    </g>
+    <use x="4" href="#c" x:href="#c"/>
+  </g>
+  <use y="2" href="#b" x:href="#b"/>
+</g>
+<use y="4" href="#a" x:href="#a"/>
+</svg>

--- a/src/chessground/Chessground.tsx
+++ b/src/chessground/Chessground.tsx
@@ -10,6 +10,7 @@ const BOARD_COORDINATE_COLORS: Record<string, { white: string; black: string }> 
   blue: { white: "#dee3e6", black: "#788a94" },
   blue2: { white: "#97b2c7", black: "#546f82" },
   blue3: { white: "#d9e0e6", black: "#315991" },
+  blue4: { white: "#e9e9d1", black: "#4e7293" },
   "blue-marble": { white: "#eae6dd", black: "#7c7f87" },
   canvas2: { white: "#d7daeb", black: "#547388" },
   wood: { white: "#d8a45b", black: "#9b4d0f" },

--- a/src/components/settings/BoardSelect.tsx
+++ b/src/components/settings/BoardSelect.tsx
@@ -16,6 +16,7 @@ const boardImages: string[] = [
   "blue.png",
   "blue2.jpg",
   "blue3.jpg",
+  "blue4.svg",
   "blue-marble.jpg",
   "canvas2.jpg",
   "wood.jpg",


### PR DESCRIPTION
## Summary

Adds a new `blue4` board theme inspired by Chess.com’s dark blue board theme.

## Changes

- Added the new `public/board/blue4.svg` board asset.
- Registered `blue4` coordinate colors in `Chessground`.
- Added `blue4.svg` to the board selection list in settings.