### PR TITLE
Remember engine state

### DIFF
--- a/src/components/boards/BoardAnalysis.tsx
+++ b/src/components/boards/BoardAnalysis.tsx
@@ -192,7 +192,7 @@ function BoardAnalysis() {
             w="100%"
             h="100%"
             value={currentTabSelected}
-            onChange={(v) => setCurrentTabSelected(v || "info")}
+            onChange={(v) => setCurrentTabSelected(v || "analysis")}
             keepMounted={false}
             activateTabWithKeyboard={false}
             style={{

--- a/src/components/panels/analysis/BestMoves.tsx
+++ b/src/components/panels/analysis/BestMoves.tsx
@@ -86,6 +86,7 @@ function BestMovesComponent({
       defaultSettings: engine.settings ?? undefined,
       defaultGo: engine.go ?? undefined,
       tab: activeTab!,
+      enabled: !!engine.enabled,
     }),
   );
 
@@ -95,6 +96,7 @@ function BestMovesComponent({
         ...prev,
         go: engine.go || prev.go,
         settings: engine.settings || prev.settings,
+        enabled: engine.enabled || prev.enabled,
       }));
     }
   }, [engine.settings, engine.go, settings.synced, setSettings2]);
@@ -106,7 +108,14 @@ function BestMovesComponent({
       if (newSettings.synced) {
         setEngines(async (prev) =>
           (await prev).map((o) =>
-            o.id === engine.id ? { ...o, settings: newSettings.settings, go: newSettings.go } : o,
+            o.id === engine.id
+              ? {
+                  ...o,
+                  settings: newSettings.settings,
+                  go: newSettings.go,
+                  enabled: newSettings.enabled,
+                }
+              : o,
           ),
         );
       }

--- a/src/components/puzzles/Puzzles.tsx
+++ b/src/components/puzzles/Puzzles.tsx
@@ -564,6 +564,7 @@ function Puzzles({ id }: { id: string }) {
                             ? "black"
                             : "white",
                       },
+                      position: [0],
                     })
                   }
                 >

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -371,7 +371,7 @@ export const currentShowCommentsAtom = tabValue(showCommentsFamily);
 const showVariationsFamily = atomFamily((_tab: string) => atom(true));
 export const currentShowVariationsAtom = tabValue(showVariationsFamily);
 
-export const tabFamily = atomFamily((_tab: string) => atom("info"));
+export const tabFamily = atomFamily((_tab: string) => atom("analysis"));
 export const currentTabSelectedAtom = tabValue(tabFamily);
 
 const reportModalOpenFamily = atomFamily((_tab: string) => atom(false));
@@ -639,11 +639,13 @@ export const tabEngineSettingsFamily = atomFamily(
         engineId: _engineId,
         defaultSettings,
         defaultGo,
+        enabled,
     }: {
         tab: string;
         engineId: string;
         defaultSettings?: EngineSettings;
         defaultGo?: GoMode;
+        enabled?: boolean;
     }) => {
         return atom<{
             enabled: boolean;
@@ -651,7 +653,7 @@ export const tabEngineSettingsFamily = atomFamily(
             go: GoMode;
             synced: boolean;
         }>({
-            enabled: false,
+            enabled: !!enabled,
             settings: defaultSettings || [],
             go: defaultGo || { t: "Infinite" },
             synced: true,
@@ -672,6 +674,7 @@ export const allEnabledAtom = atom((get) => {
                 engineId: engine.id,
                 defaultSettings: engine.type === "local" ? engine.settings || [] : undefined,
                 defaultGo: engine.go ?? undefined,
+                enabled: !!engine.enabled,
             });
             return get(atom).enabled;
         });
@@ -692,4 +695,5 @@ export const enableAllAtom = atom(null, (get, set, value: boolean) => {
         });
         set(atom, { ...get(atom), enabled: value });
     }
+    set(enginesAtom, async (prev) => (await prev).map((o) => ({ ...o, enabled: value })));
 });


### PR DESCRIPTION
Convenient changes for analysis puzzles: 

Fix: Remember last enabled engine, and enable it automatically in analysis page. #833
Add: make the first move in analysis as it does in puzzle