### PR TITLE
Fix: arrows and circles disappearing on puzzle board when Track Time is on

### DIFF
--- a/src/components/puzzles/PuzzleBoard.tsx
+++ b/src/components/puzzles/PuzzleBoard.tsx
@@ -34,6 +34,7 @@ function PuzzleBoard({
   const position = useStore(store, (s) => s.position);
   const moveHighlight = useAtomValue(moveHighlightAtom);
   const boardShapes = useStore(store, (s) => s.currentNode().shapes);
+  const setShapes = useStore(store, (s) => s.setShapes);
   const makeMove = useStore(store, (s) => s.makeMove);
   const makeMoves = useStore(store, (s) => s.makeMoves);
   const reset = useForceUpdate();
@@ -146,6 +147,9 @@ function PuzzleBoard({
             enabled: true,
             visible: true,
             autoShapes: boardShapes,
+            onChange: (shapes) => {
+              setShapes(shapes);
+            },
           }}
           movable={{
             free: false,


### PR DESCRIPTION
Closes #837.

When Track Time is enabled on the puzzle page, drawing an arrow or circle with right-click would make it vanish almost immediately. After a bit of digging, the cause turned out to be unrelated to the timer feature itself — Track Time just made the bug visible.

The puzzle board passes `autoShapes: boardShapes` to chessground but, unlike the main analysis board, never wires up an `onChange` handler for the drawable. That means user-drawn shapes only ever live in chessground's internal state. They never make it back into the tree node, so the very next render rewrites `autoShapes` with the stored (empty) array and the drawing disappears.

Without Track Time, the puzzle page rarely re-renders after a shape is drawn, so the issue goes unnoticed. With Track Time on, the display tick fires `setTick` every 100ms to refresh the elapsed-time label, which triggers a re-render and wipes the shape almost instantly.

The fix mirrors what `Board.tsx` already does for the analysis board: forward chessground's `onChange` to the tree store's `setShapes`, so user-drawn arrows and circles get persisted alongside the existing auto-shapes.

## How I tested
- `pnpm test` — all 40 tests pass
- `pnpm lint:fix` — no new warnings or errors
- `tsgo --noEmit` — clean
- Manually: enabled Track Time, started a new puzzle, drew arrows and circles. They stick now, and the timer keeps ticking as expected. Disabling Track Time still works the same as before.