### PR TITLE
fix: import hang and tab-close failure on large PGNs (sessionStorage quota)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "i18next-browser-languagedetector": "^8.2.1",
     "immer": "^11.1.4",
     "jotai": "^2.18.1",
+    "lz-string": "^1.5.0",
     "mantine-contextmenu": "^8.3.13",
     "mantine-datatable": "^8.3.13",
     "mantine-flagpack": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       jotai:
         specifier: ^2.18.1
         version: 2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(react@19.2.4)
+      lz-string:
+        specifier: ^1.5.0
+        version: 1.5.0
       mantine-contextmenu:
         specifier: ^8.3.13
         version: 8.3.13(@mantine/core@8.3.14(@mantine/hooks@8.3.14(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mantine/hooks@8.3.14(react@19.2.4))(clsx@2.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2873,6 +2876,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -6419,6 +6426,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:

--- a/src/components/tabs/BoardsPage.tsx
+++ b/src/components/tabs/BoardsPage.tsx
@@ -10,6 +10,7 @@ import { match } from "ts-pattern";
 import { commands } from "@/bindings";
 import { activeTabAtom, tabsAtom } from "@/state/atoms";
 import { keyMapAtom } from "@/state/keybinds";
+import { deserializeStorageValue } from "@/state/store/debouncedStorage";
 import { createTab, genID, isPersistentGameOrigin, type Tab } from "@/utils/tabs";
 import { unwrap } from "@/utils/unwrap";
 import BoardAnalysis from "../boards/BoardAnalysis";
@@ -48,8 +49,12 @@ export default function BoardsPage() {
     async (value: string | null, forced?: boolean) => {
       if (value !== null) {
         const closedTab = tabs.find((tab) => tab.value === value);
-        const tabState = JSON.parse(sessionStorage.getItem(value) || "{}");
-        if (tabState && isPersistentGameOrigin(closedTab) && tabState.state.dirty && !forced) {
+        const raw = sessionStorage.getItem(value);
+        // Persisted tree state is LZ-compressed; decode it with the same reader the store uses.
+        const tabState = raw
+          ? deserializeStorageValue<{ version: number; state: { dirty: boolean } }>(raw)
+          : null;
+        if (tabState && isPersistentGameOrigin(closedTab) && tabState.state?.dirty && !forced) {
           toggleSaveModal();
           return;
         }

--- a/src/components/tabs/ImportModal.tsx
+++ b/src/components/tabs/ImportModal.tsx
@@ -68,134 +68,141 @@ export default function ImportModal({
   const [save, setSave] = useState(false);
   const [filename, setFilename] = useState("");
   const [error, setError] = useState("");
+  const [submitError, setSubmitError] = useState("");
   const { documentDir } = useLoaderData({ from: "/" });
   const store = useStore();
 
   async function handleSubmit() {
     setLoading(true);
-    if (importType === "PGN") {
-      if (file || pgn) {
-        if (file) {
-          let fileInfo: FileMetadata | undefined;
-          const count = unwrap(await commands.countPgnGames(file));
-          const fileContent = await readTextFile(file);
-          const input = unwrap(await commands.readGames(file, 0, 0))[0];
-          if (save) {
-            const newFile = await createFile({
-              filename,
-              filetype,
-              pgn: fileContent,
-              dir: documentDir,
-            });
-            if (newFile.isErr) {
-              setError(newFile.error.message);
-              setLoading(false);
-              return;
+    setSubmitError("");
+    try {
+      if (importType === "PGN") {
+        if (file || pgn) {
+          if (file) {
+            let fileInfo: FileMetadata | undefined;
+            const count = unwrap(await commands.countPgnGames(file));
+            const fileContent = await readTextFile(file);
+            const input = unwrap(await commands.readGames(file, 0, 0))[0];
+            if (save) {
+              const newFile = await createFile({
+                filename,
+                filetype,
+                pgn: fileContent,
+                dir: documentDir,
+              });
+              if (newFile.isErr) {
+                setError(newFile.error.message);
+                setLoading(false);
+                return;
+              }
+              fileInfo = newFile.value;
+            } else {
+              fileInfo = {
+                type: "file",
+                path: file,
+                numGames: count,
+                name: filename,
+                lastModified: Date.now(),
+                metadata: {
+                  type: "game",
+                  tags: [],
+                },
+              };
             }
-            fileInfo = newFile.value;
-          } else {
-            fileInfo = {
-              type: "file",
-              path: file,
-              numGames: count,
-              name: filename,
-              lastModified: Date.now(),
-              metadata: {
-                type: "game",
-                tags: [],
-              },
-            };
-          }
-          const tree = await parsePGN(input);
-          const originKind = (await isInTempDir(fileInfo.path)) ? "temp_file" : "file";
-          setCurrentTab((prev) => {
-            sessionStorage.setItem(prev.value, JSON.stringify({ version: 0, state: tree }));
-            return {
-              ...prev,
-              name: getGameName(tree.headers),
-              gameOrigin: {
-                kind: originKind,
-                file: fileInfo,
-                gameNumber: 0,
-              },
-              type: "analysis",
-            };
-          });
-
-          if (fileInfo?.path) {
-            store.set(addRecentFileAtom, {
-              name: fileInfo.name,
-              path: fileInfo.path,
-              type: fileInfo.metadata.type,
+            const tree = await parsePGN(input);
+            const originKind = (await isInTempDir(fileInfo.path)) ? "temp_file" : "file";
+            setCurrentTab((prev) => {
+              sessionStorage.setItem(prev.value, JSON.stringify({ version: 0, state: tree }));
+              return {
+                ...prev,
+                name: getGameName(tree.headers),
+                gameOrigin: {
+                  kind: originKind,
+                  file: fileInfo,
+                  gameNumber: 0,
+                },
+                type: "analysis",
+              };
             });
-          }
-        } else {
-          const tempFile = await resolve(await tempDir(), `import_${Date.now()}.pgn`);
-          await writeTextFile(tempFile, pgn);
-          await openFile(tempFile, setTabs, setActiveTab);
-        }
-      }
-    } else if (importType === "Link") {
-      if (!link) {
-        setLoading(false);
-        return;
-      }
-      let pgn = "";
-      if (link.includes("chess.com")) {
-        const res = await getChesscomGame(link);
-        if (res === null) {
-          setLoading(false);
-          return;
-        }
-        pgn = res;
-      } else if (link.includes("lichess")) {
-        const excludedPathParts = ["game", "export", "white", "black"];
-        const gameId = new URL(link).pathname
-          .split("/")
-          .find((x) => x && !excludedPathParts.includes(x));
-        if (!gameId) {
-          setLoading(false);
-          return;
-        }
-        pgn = await getLichessGame(gameId);
-      }
 
-      const tree = await parsePGN(pgn);
-      setCurrentTab((prev) => {
-        sessionStorage.setItem(prev.value, JSON.stringify({ version: 0, state: tree }));
-        return {
-          ...prev,
-          name: getGameName(tree.headers),
-          gameOrigin: {
-            kind: "none",
-          },
-          type: "analysis",
-        };
-      });
-    } else if (importType === "FEN") {
-      const res = parseFen(fen.trim());
-      if (res.isErr) {
-        setFenError(chessopsError(res.error));
-        setLoading(false);
-        return;
+            if (fileInfo?.path) {
+              store.set(addRecentFileAtom, {
+                name: fileInfo.name,
+                path: fileInfo.path,
+                type: fileInfo.metadata.type,
+              });
+            }
+          } else {
+            const tempFile = await resolve(await tempDir(), `import_${Date.now()}.pgn`);
+            await writeTextFile(tempFile, pgn);
+            await openFile(tempFile, setTabs, setActiveTab);
+          }
+        }
+      } else if (importType === "Link") {
+        if (!link) {
+          setLoading(false);
+          return;
+        }
+        let pgn = "";
+        if (link.includes("chess.com")) {
+          const res = await getChesscomGame(link);
+          if (res === null) {
+            setLoading(false);
+            return;
+          }
+          pgn = res;
+        } else if (link.includes("lichess")) {
+          const excludedPathParts = ["game", "export", "white", "black"];
+          const gameId = new URL(link).pathname
+            .split("/")
+            .find((x) => x && !excludedPathParts.includes(x));
+          if (!gameId) {
+            setLoading(false);
+            return;
+          }
+          pgn = await getLichessGame(gameId);
+        }
+
+        const tree = await parsePGN(pgn);
+        setCurrentTab((prev) => {
+          sessionStorage.setItem(prev.value, JSON.stringify({ version: 0, state: tree }));
+          return {
+            ...prev,
+            name: getGameName(tree.headers),
+            gameOrigin: {
+              kind: "none",
+            },
+            type: "analysis",
+          };
+        });
+      } else if (importType === "FEN") {
+        const res = parseFen(fen.trim());
+        if (res.isErr) {
+          setFenError(chessopsError(res.error));
+          setLoading(false);
+          return;
+        }
+        setFenError("");
+        const parsedFen = makeFen(res.value);
+        setCurrentTab((prev) => {
+          const tree = defaultTree(parsedFen);
+          tree.headers.fen = parsedFen;
+          sessionStorage.setItem(prev.value, JSON.stringify({ version: 0, state: tree }));
+          return {
+            ...prev,
+            name: t("Home.Card.AnalysisBoard.Title"),
+            gameOrigin: {
+              kind: "none",
+            },
+            type: "analysis",
+          };
+        });
       }
-      setFenError("");
-      const parsedFen = makeFen(res.value);
-      setCurrentTab((prev) => {
-        const tree = defaultTree(parsedFen);
-        tree.headers.fen = parsedFen;
-        sessionStorage.setItem(prev.value, JSON.stringify({ version: 0, state: tree }));
-        return {
-          ...prev,
-          name: t("Home.Card.AnalysisBoard.Title"),
-          gameOrigin: {
-            kind: "none",
-          },
-          type: "analysis",
-        };
-      });
+    } catch (e) {
+      setSubmitError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
   }
 
   const Input = match(importType)
@@ -352,6 +359,12 @@ export default function ImportModal({
       >
         {loading ? t("Import.Importing") : t("Home.Card.ImportGame.Button")}
       </Button>
+
+      {submitError && (
+        <Text c="red" size="sm" mt="xs">
+          {submitError}
+        </Text>
+      )}
     </Modal>
   );
 }

--- a/src/components/tabs/ImportModal.tsx
+++ b/src/components/tabs/ImportModal.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from "react-i18next";
 import { match } from "ts-pattern";
 import { commands } from "@/bindings";
 import { addRecentFileAtom, currentTabAtom } from "@/state/atoms";
+import { serializeStorageValue } from "@/state/store/debouncedStorage";
 import { parsePGN } from "@/utils/chess";
 import { getChesscomGame } from "@/utils/chess.com/api";
 import { chessopsError } from "@/utils/chessops";
@@ -112,7 +113,10 @@ export default function ImportModal({
             const tree = await parsePGN(input);
             const originKind = (await isInTempDir(fileInfo.path)) ? "temp_file" : "file";
             setCurrentTab((prev) => {
-              sessionStorage.setItem(prev.value, JSON.stringify({ version: 0, state: tree }));
+              sessionStorage.setItem(
+                prev.value,
+                serializeStorageValue({ version: 0, state: tree }),
+              );
               return {
                 ...prev,
                 name: getGameName(tree.headers),
@@ -165,7 +169,7 @@ export default function ImportModal({
 
         const tree = await parsePGN(pgn);
         setCurrentTab((prev) => {
-          sessionStorage.setItem(prev.value, JSON.stringify({ version: 0, state: tree }));
+          sessionStorage.setItem(prev.value, serializeStorageValue({ version: 0, state: tree }));
           return {
             ...prev,
             name: getGameName(tree.headers),
@@ -187,7 +191,7 @@ export default function ImportModal({
         setCurrentTab((prev) => {
           const tree = defaultTree(parsedFen);
           tree.headers.fen = parsedFen;
-          sessionStorage.setItem(prev.value, JSON.stringify({ version: 0, state: tree }));
+          sessionStorage.setItem(prev.value, serializeStorageValue({ version: 0, state: tree }));
           return {
             ...prev,
             name: t("Home.Card.AnalysisBoard.Title"),

--- a/src/state/store/debouncedStorage.ts
+++ b/src/state/store/debouncedStorage.ts
@@ -1,4 +1,22 @@
+import { compressToUTF16, decompressFromUTF16 } from "lz-string";
 import { type PersistStorage, type StorageValue } from "zustand/middleware";
+
+// Tree state is persisted compressed. A ~6,600-node game serializes to ~1.5MB of JSON, which
+// fills the ~5MB sessionStorage quota after a couple of tabs. compressToUTF16 shrinks it ~5x
+// with an exact (lossless) round-trip and stays synchronous (no async hydration / flash). The
+// seed writes in createTab / ImportModal use these same helpers so the store reads them back.
+export function serializeStorageValue(value: unknown): string {
+    return compressToUTF16(JSON.stringify(value));
+}
+
+export function deserializeStorageValue<T>(stored: string): T | null {
+    try {
+        const json = decompressFromUTF16(stored);
+        return json ? (JSON.parse(json) as T) : null;
+    } catch {
+        return null;
+    }
+}
 
 const DEBOUNCE_MS = 300;
 const pendingWrites = new Map<string, StorageValue<unknown>>();
@@ -12,7 +30,7 @@ function flush() {
     }
 
     for (const [name, value] of pendingWrites) {
-        sessionStorage.setItem(name, JSON.stringify(value));
+        sessionStorage.setItem(name, serializeStorageValue(value));
     }
 
     pendingWrites.clear();
@@ -60,7 +78,7 @@ export function createDebouncedSessionStorage<S>(delay = DEBOUNCE_MS): PersistSt
             }
 
             const stored = sessionStorage.getItem(name);
-            return stored ? (JSON.parse(stored) as StorageValue<S>) : null;
+            return stored ? deserializeStorageValue<StorageValue<S>>(stored) : null;
         },
         setItem: (name, value) => {
             pendingWrites.set(name, value as StorageValue<unknown>);

--- a/src/utils/tabs.ts
+++ b/src/utils/tabs.ts
@@ -120,7 +120,14 @@ export async function createTab({
                 tree.position = position;
             }
         }
-        sessionStorage.setItem(id, JSON.stringify({ version: 0, state: tree }));
+        try {
+            sessionStorage.setItem(id, JSON.stringify({ version: 0, state: tree }));
+        } catch (e) {
+            throw new Error(
+                "Could not open the game: the browser's session storage is full. Close some open tabs and try again.",
+                { cause: e },
+            );
+        }
     }
 
     setTabs((prev) => {

--- a/src/utils/tabs.ts
+++ b/src/utils/tabs.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { StoreApi } from "zustand";
 import { commands } from "@/bindings";
 import { type FileMetadata, fileMetadataSchema } from "@/components/files/file";
+import { serializeStorageValue } from "@/state/store/debouncedStorage";
 import type { TreeStoreState } from "@/state/store/tree";
 import { getPGN, parsePGN } from "./chess";
 import { type GameHeaders, getGameName } from "./treeReducer";
@@ -121,7 +122,7 @@ export async function createTab({
             }
         }
         try {
-            sessionStorage.setItem(id, JSON.stringify({ version: 0, state: tree }));
+            sessionStorage.setItem(id, serializeStorageValue({ version: 0, state: tree }));
         } catch (e) {
             throw new Error(
                 "Could not open the game: the browser's session storage is full. Close some open tabs and try again.",

--- a/src/utils/tests/debouncedStorage.test.ts
+++ b/src/utils/tests/debouncedStorage.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "vitest";
+import { deserializeStorageValue, serializeStorageValue } from "../../state/store/debouncedStorage";
+
+test("serialize/deserialize round-trips a storage value losslessly", () => {
+    const value = {
+        version: 0,
+        state: {
+            root: {
+                fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+                children: [],
+                comment: "line one\nline two",
+                annotations: ["!", "?"],
+                shapes: [{ orig: "e2", dest: "e4", brush: "green" }],
+                score: { type: "cp", value: { type: "cp", value: 123 } },
+            },
+            headers: { start: [0, 1], orientation: "white" },
+            position: [0, 0],
+        },
+    };
+
+    const restored = deserializeStorageValue(serializeStorageValue(value));
+
+    expect(restored).toEqual(value);
+});
+
+test("compressed payload is smaller than raw JSON for a large tree", () => {
+    const big = {
+        state: {
+            root: {
+                children: Array.from({ length: 3000 }, (_, i) => ({
+                    fen: `rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 ${i}`,
+                    san: "e4",
+                    comment: "",
+                })),
+            },
+        },
+    };
+
+    const raw = JSON.stringify(big);
+    const compressed = serializeStorageValue(big);
+
+    expect(compressed.length).toBeLessThan(raw.length);
+});
+
+test("deserialize returns null for empty or corrupt input instead of throwing", () => {
+    expect(deserializeStorageValue("")).toBeNull();
+    expect(deserializeStorageValue("not-valid-lz-data")).toBeNull();
+});


### PR DESCRIPTION
Importing a large PGN (path import / save-to-collection / repertoire) hung the modal on a stuck spinner. Root cause: `sessionStorage.setItem` threw `QuotaExceededError` (WebKit ~5MB, UTF-16) when serialized tab state exceeded quota, with no error handling — and a follow-on bug where `closeTab` ran `JSON.parse` on data that had become compressed, throwing and silently blocking tab close.

Fix:
1. Handle import failures with a friendly error instead of an infinite spinner.
2. Compress persisted tree state with `lz-string` `compressToUTF16` (~5x) so it fits the quota.
3. Decode the compressed state in `closeTab`.

Adds a dependency (`lz-string`) and storage round-trip tests.
