### PR TITLE
fix: engine id collisions

### DIFF
--- a/src/components/engines/AddEngine.tsx
+++ b/src/components/engines/AddEngine.tsx
@@ -134,7 +134,14 @@ function AddEngine({
             submitLabel={t("Common.Add")}
             form={form}
             onSubmit={(values: LocalEngine) => {
-              setEngines(async (prev) => [...(await prev), values]);
+              setEngines(async (prev) => [
+                ...(await prev),
+                {
+                  ...values,
+                  id: crypto.randomUUID(),
+                },
+              ]);
+              form.setFieldValue("id", crypto.randomUUID());
               setOpened(false);
             }}
           />

--- a/src/components/engines/EnginesPage.tsx
+++ b/src/components/engines/EnginesPage.tsx
@@ -591,7 +591,7 @@ function EngineSettings({
           opened={deleteModal}
           onClose={toggleDeleteModal}
           onConfirm={() => {
-            setEngines(async (prev) => (await prev).filter((e) => e.name !== engine.name));
+            setEngines(async (prev) => (await prev).filter((e) => e.id !== engine.id));
             setSelected(null);
             toggleDeleteModal();
           }}
@@ -599,14 +599,17 @@ function EngineSettings({
         />
       </Stack>
       <JSONModal
-        key={engine.name}
+        key={engine.id}
         opened={jsonModal}
         toggleOpened={toggleJSONModal}
         engine={engine}
         setEngine={(v) =>
           setEngines(async (prev) => {
             const copy = [...(await prev)];
-            copy[selected] = v;
+            const hasDuplicateId = copy.some(
+              (engine, index) => index !== selected && engine.id === v.id,
+            );
+            copy[selected] = hasDuplicateId ? { ...v, id: crypto.randomUUID() } : v;
             return copy;
           })
         }

--- a/src/components/panels/analysis/AnalysisPanel.tsx
+++ b/src/components/panels/analysis/AnalysisPanel.tsx
@@ -141,7 +141,7 @@ function AnalysisPanel() {
                   <Group grow flex={1} gap="xs">
                     {loadedEngines.map((engine, i) => (
                       <EngineSummary
-                        key={engine.name}
+                        key={engine.id}
                         engine={engine}
                         fen={rootFen}
                         moves={moves}
@@ -158,7 +158,7 @@ function AnalysisPanel() {
                 variant="separated"
                 multiple
                 chevronSize={0}
-                value={expanded ?? loadedEngines.map((e) => e.name)}
+                value={expanded ?? loadedEngines.map((e) => e.id)}
                 onChange={(v) => setExpanded(v)}
                 styles={{
                   label: {
@@ -189,14 +189,10 @@ function AnalysisPanel() {
                       <div ref={provided.innerRef} {...provided.droppableProps}>
                         <Stack w="100%" gap="xs">
                           {loadedEngines.map((engine, i) => (
-                            <Draggable
-                              key={engine.name + i.toString()}
-                              draggableId={engine.name}
-                              index={i}
-                            >
+                            <Draggable key={engine.id} draggableId={engine.id} index={i}>
                               {(provided) => (
                                 <div ref={provided.innerRef} {...provided.draggableProps}>
-                                  <Accordion.Item value={engine.name}>
+                                  <Accordion.Item value={engine.id}>
                                     <BestMoves
                                       id={i}
                                       engine={engine}

--- a/src/components/panels/analysis/EngineSelection.tsx
+++ b/src/components/panels/analysis/EngineSelection.tsx
@@ -66,13 +66,11 @@ function EngineSelection() {
         <Stack gap="xs" align="center" w="100%">
           {engines.map((engine) => (
             <EngineBox
-              key={engine.name}
+              key={engine.id}
               engine={engine}
               toggleEnabled={() => {
                 setEngines(async (prev) =>
-                  (await prev).map((e) =>
-                    e.name === engine.name ? { ...e, loaded: !e.loaded } : e,
-                  ),
+                  (await prev).map((e) => (e.id === engine.id ? { ...e, loaded: !e.loaded } : e)),
                 );
               }}
             />

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -150,11 +150,23 @@ const enginesFileStorage: AsyncStringStorage = {
     },
 };
 
+const enginesSchema = zodArray(engineSchema).transform((engines) => {
+    const ids = new Set<string>();
+
+    return engines.map((engine) => {
+        if (ids.has(engine.id)) {
+            return { ...engine, id: crypto.randomUUID() };
+        }
+        ids.add(engine.id);
+        return engine;
+    });
+});
+
 export const enginesAtom = unwrap(
     atomWithStorage<Engine[]>(
         "engines/engines.json",
         [],
-        createAsyncZodStorage(zodArray(engineSchema), enginesFileStorage) as AsyncStorage<Engine[]>,
+        createAsyncZodStorage(enginesSchema, enginesFileStorage) as AsyncStorage<Engine[]>,
     ),
 );
 


### PR DESCRIPTION
Fixes duplicate engine IDs that could cause Mantine Select to crash with duplicate option values.

Changes:
- Generate a fresh engine ID when adding a local engine
- Repair duplicate engine IDs when loading stored engines
- Regenerate IDs on JSON edits if they collide
- Use engine IDs instead of names for analysis UI identity


should fix #844