### PR TITLE
fix: Issue #849 handling repertoire tranpositions

### DIFF
--- a/src/components/panels/practice/RepertoireInfo.tsx
+++ b/src/components/panels/practice/RepertoireInfo.tsx
@@ -38,8 +38,9 @@ import {
   getStats,
   type PositionMove,
 } from "@/utils/repertoire";
-import { getNodeAtPath, getTreeStructureHash, type TreeNode } from "@/utils/treeReducer";
+import { getNodeAtPath, type TreeNode } from "@/utils/treeReducer";
 import classes from "./RepertoireInfo.module.css";
+import { getBoardState } from "@/state/store/tree";
 
 function formatMoveNotation(halfMoves: number, san: string): string {
   const moveNum = Math.ceil(halfMoves / 2);
@@ -58,17 +59,15 @@ function RepertoireInfo() {
   const makeMove = useStore(store, (s) => s.makeMove);
   const makeMoves = useStore(store, (s) => s.makeMoves);
   const setStart = useStore(store, (s) => s.setStart);
+  const boardStateMap = useStore(store, (s) => s.boardStateMap);
 
   const referenceDb = useAtomValue(referenceDbAtom);
   const currentTab = useAtomValue(currentTabAtom);
   const minGames = useAtomValue(coverageMinGamesAtom);
 
-  const orientation = headers.orientation || "white";
+  const orientation = useMemo(() => headers.orientation || "white", [headers.orientation]);
 
   const stats = useStore(store, getStats);
-
-  const rootStructureHash = useMemo(() => getTreeStructureHash(root), [root]);
-
   const [rawOpenings, setRawOpenings] = useState<
     { move: string; white: number; draw: number; black: number }[]
   >([]);
@@ -115,12 +114,35 @@ function RepertoireInfo() {
   const [coverageLoading, setCoverageLoading] = useState(false);
   const coverageVersionRef = useRef(0);
 
-  const startPath = headers.start || [];
-  const startPathKey = startPath.join(",");
+  const startPath = useMemo(() => headers.start || [], [headers.start]);
   const hasStart = headers.start != null && headers.start.length > 0;
   const isBeforeStart =
     hasStart && position.length < startPath.length && isPrefix(position, startPath);
   const isEmptyTree = root.children.length === 0;
+
+  const startNode = useMemo(() => getNodeAtPath(root, startPath), [root, startPath]);
+
+  const startStateMoves = useMemo(() => {
+    const movesMap = new Map<string, Map<string, string>>();
+    if (!startNode) return movesMap;
+
+    for (const [fen, entries] of Object.entries(boardStateMap)) {
+      const perFenMap = new Map<string, string>();
+      for (const { node, path } of entries) {
+        if (isPrefix(startPath, path)) {
+          for (const child of node.children) {
+            if (child.san) {
+              perFenMap.set(child.san, getBoardState(child.fen));
+            }
+          }
+        }
+      }
+      if (perFenMap.size > 0) {
+        movesMap.set(fen, perFenMap);
+      }
+    }
+    return movesMap;
+  }, [boardStateMap, startNode, startPath]);
 
   useEffect(() => {
     if (!referenceDb) {
@@ -132,15 +154,46 @@ function RepertoireInfo() {
     }
     const version = ++coverageVersionRef.current;
     setCoverageLoading(true);
-    computeTreeCoverage(root, orientation, referenceDb, minGames, startPath).then((result) => {
-      if (version === coverageVersionRef.current) {
-        setCoverageMap(result.coverageMap);
-        setGamesMap(result.gamesMap);
-        setMissingGamesMap(result.missingGamesMap);
-        setCoverageLoading(false);
+
+    computeTreeCoverage(root, orientation, referenceDb, minGames, startPath, startStateMoves).then(
+      (result) => {
+        if (version === coverageVersionRef.current) {
+          setCoverageMap(result.coverageMap);
+          setGamesMap(result.gamesMap);
+          setMissingGamesMap(result.missingGamesMap);
+          setCoverageLoading(false);
+        }
+      },
+    );
+  }, [root, orientation, referenceDb, minGames, startPath, startStateMoves]);
+
+  const nodeToPath = useMemo(() => {
+    const map = new Map<TreeNode, number[]>();
+    for (const entries of Object.values(boardStateMap)) {
+      for (const { node, path } of entries) {
+        map.set(node, path);
       }
-    });
-  }, [rootStructureHash, orientation, referenceDb, startPathKey, minGames]);
+    }
+    return map;
+  }, [boardStateMap]);
+
+  const transpositionMoves = useMemo(() => {
+    const boardFen = getBoardState(currentNode.fen);
+    const entries = boardStateMap[boardFen] || [];
+    const moveMap = new Map<string, number[]>();
+    for (const { node, path } of entries) {
+      if (!isPrefix(startPath, path)) continue;
+      for (const child of node.children) {
+        if (child.san && !moveMap.has(child.san)) {
+          const childPath = nodeToPath.get(child);
+          if (childPath && isPrefix(startPath, childPath)) {
+            moveMap.set(child.san, childPath);
+          }
+        }
+      }
+    }
+    return moveMap;
+  }, [currentNode.fen, boardStateMap, nodeToPath, startPath]);
 
   const positionMoves = useMemo(() => {
     const total = rawOpenings.reduce((acc, op) => acc + op.white + op.black + op.draw, 0);
@@ -148,9 +201,9 @@ function RepertoireInfo() {
     const fromDb: PositionMove[] = rawOpenings
       .map((op) => {
         const games = op.white + op.black + op.draw;
-        const childIndex = currentNode.children.findIndex((c) => c.san === op.move);
-        const inRepertoire = childIndex !== -1;
-        const coveragePath = [...position, childIndex].join(",");
+        const targetPath = transpositionMoves.get(op.move);
+        const inRepertoire = targetPath !== undefined;
+        const coveragePath = targetPath ? targetPath.join(",") : "";
         const coverage = inRepertoire ? (coverageMap.get(coveragePath) ?? 0) : 0;
 
         return {
@@ -163,23 +216,19 @@ function RepertoireInfo() {
           black: games > 0 ? op.black / games : 0,
           inRepertoire,
           coverage,
-          childIndex,
+          path: targetPath || [],
         };
       })
       .sort((a, b) => b.frequency - a.frequency);
 
-    // Include repertoire children not found in the DB
-    const dbSans = new Set(rawOpenings.map((op) => op.move));
-    const fromTree: PositionMove[] = currentNode.children
-      .map((child, idx) => ({ child, idx }))
-      .filter(
-        (entry): entry is { child: TreeNode & { san: string }; idx: number } =>
-          entry.child.san !== null && !dbSans.has(entry.child.san),
-      )
-      .map(({ child, idx }) => {
-        const coveragePath = [...position, idx].join(",");
-        return {
-          san: child.san,
+    // Add prepared moves not present in DB
+    const usedSans = new Set(fromDb.map((m) => m.san));
+    for (const [san, targetPath] of transpositionMoves) {
+      if (!usedSans.has(san)) {
+        const coveragePath = targetPath.join(",");
+        const coverage = coverageMap.get(coveragePath) ?? 0;
+        fromDb.push({
+          san,
           games: 0,
           totalGames: total,
           frequency: 0,
@@ -187,26 +236,27 @@ function RepertoireInfo() {
           draw: 0,
           black: 0,
           inRepertoire: true,
-          coverage: coverageMap.get(coveragePath) ?? 0,
-          childIndex: idx,
-        };
-      });
+          coverage,
+          path: targetPath,
+        });
+      }
+    }
 
-    return [...fromDb, ...fromTree];
-  }, [rawOpenings, currentNode.children, position, coverageMap]);
+    return fromDb;
+  }, [rawOpenings, transpositionMoves, coverageMap]);
 
   const isUserTurn =
     orientation === "white" ? currentNode.halfMoves % 2 === 0 : currentNode.halfMoves % 2 === 1;
 
   const handleMoveClick = useCallback(
     (move: PositionMove) => {
-      if (move.inRepertoire) {
-        goToMove([...position, move.childIndex]);
+      if (move.inRepertoire && move.path.length > 0) {
+        goToMove(move.path);
       } else {
         makeMove({ payload: move.san });
       }
     },
-    [position, goToMove, makeMove],
+    [goToMove, makeMove],
   );
 
   const nextGap = useMemo(
@@ -337,7 +387,6 @@ function RepertoireInfo() {
         <MovesView
           isUserTurn={isUserTurn}
           currentNode={currentNode}
-          position={position}
           positionMoves={positionMoves}
           coverageMap={coverageMap}
           coverageLoading={coverageLoading}
@@ -348,6 +397,9 @@ function RepertoireInfo() {
           onMoveClick={handleMoveClick}
           t={t}
           minGames={minGames}
+          boardStateMap={boardStateMap}
+          nodeToPath={nodeToPath}
+          startPath={startPath}
         />
       )}
       <Divider pb="sm" />
@@ -378,10 +430,21 @@ function TreeStatsBar({
   );
 }
 
+type TResponse = {
+  san: string;
+  halfMoves: number;
+  childPath: number[];
+  coverage: number;
+  dbGames: number;
+  dbFrequency: number;
+  white: number;
+  draw: number;
+  black: number;
+};
+
 function MovesView({
   isUserTurn,
   currentNode,
-  position,
   positionMoves,
   coverageMap,
   coverageLoading,
@@ -392,10 +455,12 @@ function MovesView({
   onMoveClick,
   t,
   minGames,
+  boardStateMap,
+  nodeToPath,
+  startPath,
 }: {
   isUserTurn: boolean;
   currentNode: TreeNode;
-  position: number[];
   positionMoves: PositionMove[];
   coverageMap: Map<string, number>;
   coverageLoading: boolean;
@@ -406,29 +471,55 @@ function MovesView({
   onMoveClick: (move: PositionMove) => void;
   t: ReturnType<typeof useTranslation>["t"];
   minGames: number;
+  boardStateMap: Record<string, { node: TreeNode; path: number[] }[]>;
+  nodeToPath: Map<TreeNode, number[]>;
+  startPath: number[];
 }) {
-  const hasResponses = currentNode.children.length > 0;
-  const [showRare, setShowRare] = useState(false);
+  const unifiedUserResponses: TResponse[] = useMemo(() => {
+    if (!isUserTurn) return [];
+    const boardFen = getBoardState(currentNode.fen);
+    const entries = boardStateMap[boardFen] || [];
+    const seenSans = new Set<string>();
+    const responses: TResponse[] = [];
 
-  const responsesWithStats = useMemo(() => {
-    if (!isUserTurn || !hasResponses) return [];
-    return currentNode.children.map((child, idx) => {
-      const dbEntry = positionMoves.find((pm) => pm.san === child.san);
-      const coveragePath = [...position, idx].join(",");
-      const coverage = coverageMap.get(coveragePath) ?? 0;
-      return {
-        san: child.san || "",
-        halfMoves: child.halfMoves,
-        dbGames: dbEntry?.games ?? 0,
-        dbFrequency: dbEntry?.frequency ?? 0,
-        white: dbEntry?.white ?? 0,
-        draw: dbEntry?.draw ?? 0,
-        black: dbEntry?.black ?? 0,
-        coverage,
-        childPath: [...position, idx],
-      };
-    });
-  }, [isUserTurn, hasResponses, currentNode.children, positionMoves, position, coverageMap]);
+    for (const { node, path } of entries) {
+      if (!isPrefix(startPath, path)) continue;
+      for (const child of node.children) {
+        if (child.san && !seenSans.has(child.san)) {
+          const childPath = nodeToPath.get(child);
+          if (childPath && isPrefix(startPath, childPath)) {
+            seenSans.add(child.san);
+            const coveragePath = childPath.join(",");
+            const coverage = coverageMap.get(coveragePath) ?? 0;
+            const dbEntry = positionMoves.find((pm) => pm.san === child.san);
+            responses.push({
+              san: child.san,
+              halfMoves: child.halfMoves,
+              childPath,
+              coverage,
+              dbGames: dbEntry?.games ?? 0,
+              dbFrequency: dbEntry?.frequency ?? 0,
+              white: dbEntry?.white ?? 0,
+              draw: dbEntry?.draw ?? 0,
+              black: dbEntry?.black ?? 0,
+            });
+          }
+        }
+      }
+    }
+    return responses;
+  }, [
+    isUserTurn,
+    currentNode.fen,
+    boardStateMap,
+    nodeToPath,
+    coverageMap,
+    positionMoves,
+    startPath,
+  ]);
+
+  const hasResponses = unifiedUserResponses.length > 0;
+  const [showRare, setShowRare] = useState(false);
 
   const relevantMoves = useMemo(
     () => (isUserTurn ? [] : positionMoves.filter((m) => m.games >= minGames)),
@@ -533,7 +624,7 @@ function MovesView({
 
           {isUserTurn &&
             hasResponses &&
-            responsesWithStats.map((response) => (
+            unifiedUserResponses.map((response) => (
               <MoveRow
                 key={response.san}
                 move={{
@@ -546,7 +637,7 @@ function MovesView({
                   black: response.black,
                   inRepertoire: true,
                   coverage: response.coverage,
-                  childIndex: 0,
+                  path: response.childPath,
                 }}
                 halfMoves={response.halfMoves}
                 onClick={() => goToMove(response.childPath)}

--- a/src/components/panels/practice/RepertoireInfo.tsx
+++ b/src/components/panels/practice/RepertoireInfo.tsx
@@ -608,7 +608,7 @@ function MovesView({
               <Text fz="xs" c="dimmed" w={100} ta="center">
                 {t("Board.Practice.Build.Results")}
               </Text>
-              {(hasResponses || coverageLoading) && (
+              {(!isUserTurn || hasResponses || coverageLoading) && (
                 <Group gap={4} w={100} justify="center" wrap="nowrap">
                   <Text fz="xs" c="dimmed" ta="center">
                     {t("Board.Practice.Build.YourCoverage")}

--- a/src/components/panels/practice/RepertoireInfo.tsx
+++ b/src/components/panels/practice/RepertoireInfo.tsx
@@ -28,19 +28,18 @@ import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
 import { TreeStateContext } from "@/components/common/TreeStateContext";
 import { coverageMinGamesAtom, currentTabAtom, referenceDbAtom } from "@/state/atoms";
-import { searchPosition } from "@/utils/db";
 import { roundKeepSum } from "@/utils/format";
 import { isPrefix } from "@/utils/misc";
 import {
   computeTreeCoverage,
+  fetchPositionMoves,
   findBiggestGap,
   findNextGap,
   getStats,
   type PositionMove,
 } from "@/utils/repertoire";
-import { getNodeAtPath, type TreeNode } from "@/utils/treeReducer";
+import { getBoardState, getNodeAtPath, type TreeNode } from "@/utils/treeReducer";
 import classes from "./RepertoireInfo.module.css";
-import { getBoardState } from "@/state/store/tree";
 
 function formatMoveNotation(halfMoves: number, san: string): string {
   const moveNum = Math.ceil(halfMoves / 2);
@@ -51,6 +50,7 @@ function formatMoveNotation(halfMoves: number, san: string): string {
 function RepertoireInfo() {
   const { t } = useTranslation();
   const store = useContext(TreeStateContext)!;
+  const dirty = useStore(store, (s) => s.dirty);
   const root = useStore(store, (s) => s.root);
   const headers = useStore(store, (s) => s.headers);
   const position = useStore(store, (s) => s.position);
@@ -68,51 +68,20 @@ function RepertoireInfo() {
   const orientation = useMemo(() => headers.orientation || "white", [headers.orientation]);
 
   const stats = useStore(store, getStats);
-  const [rawOpenings, setRawOpenings] = useState<
-    { move: string; white: number; draw: number; black: number }[]
-  >([]);
-  const [loading, setLoading] = useState(false);
-
-  const currentFenRef = useRef(currentNode.fen);
-  currentFenRef.current = currentNode.fen;
-
-  useEffect(() => {
-    if (!referenceDb) {
-      setRawOpenings([]);
-      return;
-    }
-
-    const queryFen = currentNode.fen;
-    setLoading(true);
-
-    searchPosition(
-      {
-        path: referenceDb,
-        type: "exact",
-        fen: queryFen,
-        color: "white",
-        player: null,
-        result: "any",
-      },
-      "build-tab",
-    )
-      .then(([openings]) => {
-        if (queryFen !== currentFenRef.current) return;
-        setRawOpenings(openings.filter((op) => op.move !== "*"));
-        setLoading(false);
-      })
-      .catch(() => {
-        if (queryFen !== currentFenRef.current) return;
-        setRawOpenings([]);
-        setLoading(false);
-      });
-  }, [currentNode.fen, referenceDb]);
 
   const [coverageMap, setCoverageMap] = useState<Map<string, number>>(new Map());
+  const [dbMovesMap, setDbMovesMap] = useState<
+    Map<
+      string,
+      { moves: { move: string; white: number; draw: number; black: number }[]; total: number }
+    >
+  >(new Map());
   const [gamesMap, setGamesMap] = useState<Map<string, number>>(new Map());
   const [missingGamesMap, setMissingGamesMap] = useState<Map<string, number>>(new Map());
+  const [currentPosLoading, setCurrentPosLoading] = useState(false);
   const [coverageLoading, setCoverageLoading] = useState(false);
   const coverageVersionRef = useRef(0);
+  const firstCoverageRun = useRef(true);
 
   const startPath = useMemo(() => headers.start || [], [headers.start]);
   const hasStart = headers.start != null && headers.start.length > 0;
@@ -145,13 +114,39 @@ function RepertoireInfo() {
   }, [boardStateMap, startNode, startPath]);
 
   useEffect(() => {
+    if (!referenceDb) return;
+    const boardFen = getBoardState(currentNode.fen);
+    if (dbMovesMap.has(boardFen)) return;
+
+    setCurrentPosLoading(true);
+    fetchPositionMoves(referenceDb, boardFen)
+      .then((data) => {
+        setDbMovesMap((prev) => {
+          if (prev.has(boardFen)) return prev; // may have been filled by coverage meanwhile
+          const next = new Map(prev);
+          next.set(boardFen, data);
+          return next;
+        });
+        setCurrentPosLoading(false);
+      })
+      .catch(() => setCurrentPosLoading(false));
+  }, [currentNode.fen, referenceDb, dbMovesMap]);
+
+  useEffect(() => {
     if (!referenceDb) {
       setCoverageMap(new Map());
       setGamesMap(new Map());
       setMissingGamesMap(new Map());
+      setDbMovesMap(new Map());
       setCoverageLoading(false);
+      firstCoverageRun.current = true;
       return;
     }
+
+    if (!dirty && !firstCoverageRun.current && referenceDb && minGames) {
+      return;
+    }
+
     const version = ++coverageVersionRef.current;
     setCoverageLoading(true);
 
@@ -161,11 +156,14 @@ function RepertoireInfo() {
           setCoverageMap(result.coverageMap);
           setGamesMap(result.gamesMap);
           setMissingGamesMap(result.missingGamesMap);
+          setDbMovesMap(result.dbMovesMap);
           setCoverageLoading(false);
+          store.getState().save(); // sets dirty to false
+          firstCoverageRun.current = false;
         }
       },
     );
-  }, [root, orientation, referenceDb, minGames, startPath, startStateMoves]);
+  }, [root, orientation, referenceDb, minGames, startPath, startStateMoves, dirty]);
 
   const nodeToPath = useMemo(() => {
     const map = new Map<TreeNode, number[]>();
@@ -196,54 +194,58 @@ function RepertoireInfo() {
   }, [currentNode.fen, boardStateMap, nodeToPath, startPath]);
 
   const positionMoves = useMemo(() => {
-    const total = rawOpenings.reduce((acc, op) => acc + op.white + op.black + op.draw, 0);
+    const boardFen = getBoardState(currentNode.fen);
+    const dbData = dbMovesMap.get(boardFen);
+    const movesFromDb = dbData?.moves ?? [];
+    const total = dbData?.total ?? 0;
 
-    const fromDb: PositionMove[] = rawOpenings
-      .map((op) => {
-        const games = op.white + op.black + op.draw;
-        const targetPath = transpositionMoves.get(op.move);
-        const inRepertoire = targetPath !== undefined;
-        const coveragePath = targetPath ? targetPath.join(",") : "";
-        const coverage = inRepertoire ? (coverageMap.get(coveragePath) ?? 0) : 0;
+    const dbMoveMap = new Map(movesFromDb.map((m) => [m.move, m]));
 
-        return {
-          san: op.move,
+    const allMoves: PositionMove[] = [];
+    const seenSans = new Set<string>();
+
+    // Prepared moves (always available)
+    for (const [san, targetPath] of transpositionMoves) {
+      const dbMove = dbMoveMap.get(san);
+      const games = dbMove ? dbMove.white + dbMove.draw + dbMove.black : 0;
+      const coveragePath = targetPath.join(",");
+      const coverage = coverageMap.get(coveragePath) ?? 0;
+      seenSans.add(san);
+      allMoves.push({
+        san,
+        games,
+        totalGames: total,
+        frequency: total > 0 ? games / total : 0,
+        white: dbMove ? (games > 0 ? dbMove.white / games : 0) : 0,
+        draw: dbMove ? (games > 0 ? dbMove.draw / games : 0) : 0,
+        black: dbMove ? (games > 0 ? dbMove.black / games : 0) : 0,
+        inRepertoire: true,
+        coverage,
+        path: targetPath,
+      });
+    }
+
+    // DB moves not in repertoire
+    for (const dbMove of movesFromDb) {
+      if (!seenSans.has(dbMove.move)) {
+        const games = dbMove.white + dbMove.draw + dbMove.black;
+        allMoves.push({
+          san: dbMove.move,
           games,
           totalGames: total,
           frequency: total > 0 ? games / total : 0,
-          white: games > 0 ? op.white / games : 0,
-          draw: games > 0 ? op.draw / games : 0,
-          black: games > 0 ? op.black / games : 0,
-          inRepertoire,
-          coverage,
-          path: targetPath || [],
-        };
-      })
-      .sort((a, b) => b.frequency - a.frequency);
-
-    // Add prepared moves not present in DB
-    const usedSans = new Set(fromDb.map((m) => m.san));
-    for (const [san, targetPath] of transpositionMoves) {
-      if (!usedSans.has(san)) {
-        const coveragePath = targetPath.join(",");
-        const coverage = coverageMap.get(coveragePath) ?? 0;
-        fromDb.push({
-          san,
-          games: 0,
-          totalGames: total,
-          frequency: 0,
-          white: 0,
-          draw: 0,
-          black: 0,
-          inRepertoire: true,
-          coverage,
-          path: targetPath,
+          white: games > 0 ? dbMove.white / games : 0,
+          draw: games > 0 ? dbMove.draw / games : 0,
+          black: games > 0 ? dbMove.black / games : 0,
+          inRepertoire: false,
+          coverage: 0,
+          path: [],
         });
       }
     }
 
-    return fromDb;
-  }, [rawOpenings, transpositionMoves, coverageMap]);
+    return allMoves.sort((a, b) => b.frequency - a.frequency);
+  }, [currentNode.fen, dbMovesMap, transpositionMoves, coverageMap]);
 
   const isUserTurn =
     orientation === "white" ? currentNode.halfMoves % 2 === 0 : currentNode.halfMoves % 2 === 1;
@@ -376,32 +378,25 @@ function RepertoireInfo() {
         </Paper>
       )}
 
-      {loading ? (
-        <Stack align="center" justify="center" style={{ flex: 1 }} py="xl">
-          <Loader size="sm" />
-          <Text fz="sm" c="dimmed">
-            {t("Board.Practice.Build.Loading")}
-          </Text>
-        </Stack>
-      ) : (
-        <MovesView
-          isUserTurn={isUserTurn}
-          currentNode={currentNode}
-          positionMoves={positionMoves}
-          coverageMap={coverageMap}
-          coverageLoading={coverageLoading}
-          root={root}
-          nextGap={nextGap}
-          biggestGap={biggestGap}
-          goToMove={goToMove}
-          onMoveClick={handleMoveClick}
-          t={t}
-          minGames={minGames}
-          boardStateMap={boardStateMap}
-          nodeToPath={nodeToPath}
-          startPath={startPath}
-        />
-      )}
+      <MovesView
+        isUserTurn={isUserTurn}
+        currentNode={currentNode}
+        positionMoves={positionMoves}
+        coverageMap={coverageMap}
+        coverageLoading={coverageLoading}
+        currentPosLoading={currentPosLoading}
+        root={root}
+        nextGap={nextGap}
+        biggestGap={biggestGap}
+        goToMove={goToMove}
+        onMoveClick={handleMoveClick}
+        t={t}
+        minGames={minGames}
+        boardStateMap={boardStateMap}
+        nodeToPath={nodeToPath}
+        startPath={startPath}
+      />
+
       <Divider pb="sm" />
       <TreeStatsBar stats={stats} t={t} />
     </Stack>
@@ -464,6 +459,7 @@ function MovesView({
   positionMoves: PositionMove[];
   coverageMap: Map<string, number>;
   coverageLoading: boolean;
+  currentPosLoading: boolean;
   root: TreeNode;
   nextGap: number[] | null;
   biggestGap: number[] | null;
@@ -525,6 +521,7 @@ function MovesView({
     () => (isUserTurn ? [] : positionMoves.filter((m) => m.games >= minGames)),
     [isUserTurn, positionMoves, minGames],
   );
+
   const rareMoves = useMemo(
     () => (isUserTurn ? [] : positionMoves.filter((m) => m.games < minGames)),
     [isUserTurn, positionMoves, minGames],
@@ -611,7 +608,7 @@ function MovesView({
               <Text fz="xs" c="dimmed" w={100} ta="center">
                 {t("Board.Practice.Build.Results")}
               </Text>
-              {hasResponses && (
+              {(hasResponses || coverageLoading) && (
                 <Group gap={4} w={100} justify="center" wrap="nowrap">
                   <Text fz="xs" c="dimmed" ta="center">
                     {t("Board.Practice.Build.YourCoverage")}
@@ -711,7 +708,7 @@ function MovesView({
             ))}
         </Stack>
 
-        {coverageLoading ? (
+        {coverageLoading && (
           <>
             <Divider />
             <Group justify="center" py="sm" gap="xs">
@@ -721,7 +718,9 @@ function MovesView({
               </Text>
             </Group>
           </>
-        ) : (
+        )}
+
+        {!coverageLoading && (
           <>
             {(nextGap || biggestGap) && (
               <>

--- a/src/components/panels/practice/RepertoireInfo.tsx
+++ b/src/components/panels/practice/RepertoireInfo.tsx
@@ -143,11 +143,12 @@ function RepertoireInfo() {
       return;
     }
 
-    if (!dirty && !firstCoverageRun.current && referenceDb && minGames) {
+    if (!dirty && !firstCoverageRun.current) {
       return;
     }
 
     const version = ++coverageVersionRef.current;
+    firstCoverageRun.current = false;
     setCoverageLoading(true);
 
     computeTreeCoverage(root, orientation, referenceDb, minGames, startPath, startStateMoves).then(
@@ -159,11 +160,10 @@ function RepertoireInfo() {
           setDbMovesMap(result.dbMovesMap);
           setCoverageLoading(false);
           store.getState().save(); // sets dirty to false
-          firstCoverageRun.current = false;
         }
       },
     );
-  }, [root, orientation, referenceDb, minGames, startPath, startStateMoves, dirty]);
+  }, [referenceDb, minGames, orientation, dirty, root, startStateMoves]);
 
   const nodeToPath = useMemo(() => {
     const map = new Map<TreeNode, number[]>();

--- a/src/state/store/tree.ts
+++ b/src/state/store/tree.ts
@@ -21,6 +21,7 @@ import {
     type TreeNode,
     type TreeState,
     treeIteratorMainLine,
+    buildTranspositionMaps,
 } from "@/utils/treeReducer";
 
 export interface TreeStoreState extends TreeState {
@@ -92,6 +93,25 @@ export interface TreeStoreState extends TreeState {
 
 export type TreeStore = ReturnType<typeof createTreeStore>;
 
+const withTranspositionMaps =
+    (config: StateCreator<TreeStoreState>): StateCreator<TreeStoreState> =>
+    (set, get, api) => {
+        const wrappedSet: typeof set = (partial, _replace) => {
+            set(
+                produce((state: Draft<TreeStoreState>) => {
+                    const updates = typeof partial === "function" ? partial(state) : partial;
+                    Object.assign(state, updates);
+                    if (updates.root !== undefined || updates.headers?.start !== undefined) {
+                        const startPath = state.headers.start || [];
+                        state.boardStateMap = buildTranspositionMaps(state.root, startPath);
+                    }
+                }),
+                false,
+            );
+        };
+        return config(wrappedSet, get, api);
+    };
+
 export const createTreeStore = (id?: string, initialTree?: TreeState) => {
     const stateCreator: StateCreator<TreeStoreState> = (set, get) => ({
         ...(initialTree ?? defaultTree()),
@@ -130,23 +150,47 @@ export const createTreeStore = (id?: string, initialTree?: TreeState) => {
         goToNext: () =>
             set((state) => {
                 const { practicePath } = state;
+                const node = getNodeAtPath(state.root, state.position);
+                if (!node) return state;
 
-                // In practice mode, block navigation past the drill position
-                if (practicePath && state.position.length >= practicePath.length) {
+                // Normal case: node has children
+                if (node.children.length > 0) {
+                    if (practicePath && state.position.length >= practicePath.length) {
+                        return state;
+                    }
+                    const childIndex = practicePath ? practicePath[state.position.length] : 0;
+                    if (!node.children[childIndex]?.move) return state;
+                    const san = node.children[childIndex].san;
+                    if (!san) return state;
+                    playSound(san.includes("x"), san.includes("+"));
+                    return {
+                        ...state,
+                        position: [...state.position, childIndex],
+                    };
+                }
+
+                // No children — try transposition fallback
+                const currentFen = getBoardState(node.fen);
+                const entries = state.boardStateMap[currentFen] || [];
+                const candidates = entries.filter((e) => e.node !== node);
+
+                if (candidates.length === 0) {
+                    if (practicePath && state.position.length >= practicePath.length) {
+                        return state;
+                    }
                     return state;
                 }
 
-                // In practice mode, follow the drill path; otherwise take first child
-                const childIndex = practicePath ? practicePath[state.position.length] : 0;
+                // DFS order guarantees candidates[0] has the smallest path
+                const { node: targetNode, path: targetPath } = candidates[0];
+                if (targetNode.children.length === 0) return state;
+                const firstChild = targetNode.children[0];
+                if (!firstChild.san) return state;
+                playSound(firstChild.san.includes("x"), firstChild.san.includes("+"));
 
-                const node = getNodeAtPath(state.root, state.position);
-                if (!node || !node.children[childIndex]?.move) return state;
-                const san = node.children[childIndex].san;
-                if (!san) return state;
-                playSound(san.includes("x"), san.includes("+"));
                 return {
                     ...state,
-                    position: [...state.position, childIndex],
+                    position: [...targetPath, 0],
                 };
             }),
         goToPrevious: () =>
@@ -515,14 +559,18 @@ export const createTreeStore = (id?: string, initialTree?: TreeState) => {
 
     if (id) {
         return createStore<TreeStoreState>()(
-            persist(stateCreator, {
+            persist(withTranspositionMaps(stateCreator), {
                 name: id,
                 storage: createDebouncedSessionStorage<TreeStoreState>(),
+                partialize: (state) => {
+                    const { boardStateMap, ...rest } = state;
+                    return rest as TreeStoreState;
+                },
             }),
         );
     }
 
-    return createStore<TreeStoreState>()(stateCreator);
+    return createStore<TreeStoreState>()(withTranspositionMaps(stateCreator));
 };
 
 function makeMove({
@@ -608,7 +656,7 @@ function makeMove({
     }
 }
 
-function getBoardState(fen: string): string {
+export function getBoardState(fen: string): string {
     return fen.split(" ").slice(0, 4).join(" ");
 }
 

--- a/src/state/store/tree.ts
+++ b/src/state/store/tree.ts
@@ -22,6 +22,7 @@ import {
     type TreeState,
     treeIteratorMainLine,
     buildTranspositionMaps,
+    getBoardState,
 } from "@/utils/treeReducer";
 
 export interface TreeStoreState extends TreeState {
@@ -93,6 +94,7 @@ export interface TreeStoreState extends TreeState {
 
 export type TreeStore = ReturnType<typeof createTreeStore>;
 
+// Defined as an outer function to avoid bloating git diff.
 const withTranspositionMaps =
     (config: StateCreator<TreeStoreState>): StateCreator<TreeStoreState> =>
     (set, get, api) => {
@@ -112,9 +114,11 @@ const withTranspositionMaps =
         return config(wrappedSet, get, api);
     };
 
-export const createTreeStore = (id?: string, initialTree?: TreeState) => {
+export const createTreeStore = (id?: string, initTree?: TreeState) => {
+    const initialTree = initTree ?? defaultTree();
     const stateCreator: StateCreator<TreeStoreState> = (set, get) => ({
-        ...(initialTree ?? defaultTree()),
+        ...initialTree,
+        boardStateMap: buildTranspositionMaps(initialTree.root, initialTree.headers.start ?? []),
 
         currentNode: () => getNodeAtPath(get().root, get().position),
         getNode: (path: number[]) => getNodeAtPath(get().root, path),
@@ -147,26 +151,23 @@ export const createTreeStore = (id?: string, initialTree?: TreeState) => {
                 }),
             ),
 
-        goToNext: () =>
+        goToNext: () => {
             set((state) => {
                 const { practicePath } = state;
                 const node = getNodeAtPath(state.root, state.position);
-                if (!node) return state;
+                if (!node) return {};
 
                 // Normal case: node has children
                 if (node.children.length > 0) {
                     if (practicePath && state.position.length >= practicePath.length) {
-                        return state;
+                        return {};
                     }
                     const childIndex = practicePath ? practicePath[state.position.length] : 0;
-                    if (!node.children[childIndex]?.move) return state;
+                    if (!node.children[childIndex]?.move) return {};
                     const san = node.children[childIndex].san;
-                    if (!san) return state;
+                    if (!san) return {};
                     playSound(san.includes("x"), san.includes("+"));
-                    return {
-                        ...state,
-                        position: [...state.position, childIndex],
-                    };
+                    return { position: [...state.position, childIndex] };
                 }
 
                 // No children — try transposition fallback
@@ -176,28 +177,25 @@ export const createTreeStore = (id?: string, initialTree?: TreeState) => {
 
                 if (candidates.length === 0) {
                     if (practicePath && state.position.length >= practicePath.length) {
-                        return state;
+                        return {};
                     }
-                    return state;
+                    return {};
                 }
 
-                // DFS order guarantees candidates[0] has the smallest path
                 const { node: targetNode, path: targetPath } = candidates[0];
-                if (targetNode.children.length === 0) return state;
+                if (targetNode.children.length === 0) return {};
                 const firstChild = targetNode.children[0];
-                if (!firstChild.san) return state;
+                if (!firstChild.san) return {};
                 playSound(firstChild.san.includes("x"), firstChild.san.includes("+"));
 
-                return {
-                    ...state,
-                    position: [...targetPath, 0],
-                };
-            }),
-        goToPrevious: () =>
+                return { position: [...targetPath, 0] };
+            });
+        },
+        goToPrevious: () => {
             set((state) => ({
-                ...state,
                 position: state.position.slice(0, -1),
-            })),
+            }));
+        },
 
         goToAnnotation: (annotation, color) =>
             set(
@@ -566,6 +564,14 @@ export const createTreeStore = (id?: string, initialTree?: TreeState) => {
                     const { boardStateMap, ...rest } = state;
                     return rest as TreeStoreState;
                 },
+                onRehydrateStorage: () => (state, error) => {
+                    if (!error && state) {
+                        state.boardStateMap = buildTranspositionMaps(
+                            state.root,
+                            state.headers.start || [],
+                        );
+                    }
+                },
             }),
         );
     }
@@ -654,10 +660,6 @@ function makeMove({
             }
         }
     }
-}
-
-export function getBoardState(fen: string): string {
-    return fen.split(" ").slice(0, 4).join(" ");
 }
 
 function isThreeFoldRepetition(state: TreeState, fen: string): boolean {

--- a/src/utils/repertoire.ts
+++ b/src/utils/repertoire.ts
@@ -1,7 +1,7 @@
 import type { LocalOptions } from "@/components/panels/database/DatabasePanel";
 import { searchPosition } from "./db";
 import { getNodeAtPath, type TreeNode, treeIterator } from "./treeReducer";
-import { TreeStoreState } from "@/state/store/tree";
+import { getBoardState, TreeStoreState } from "@/state/store/tree";
 import { memoize } from "proxy-memoize";
 
 export type PositionMove = {
@@ -14,158 +14,189 @@ export type PositionMove = {
     black: number;
     inRepertoire: boolean;
     coverage: number;
-    childIndex: number;
+    path: number[];
 };
+
+async function fetchPositionMoves(
+    dbPath: string,
+    fen: string,
+): Promise<{ moves: { move: string; games: number }[]; total: number }> {
+    try {
+        const [openings] = await searchPosition(
+            {
+                path: dbPath,
+                type: "exact",
+                fen,
+                color: "white",
+                player: null,
+                result: "any",
+            } as LocalOptions,
+            "coverage-calc",
+        );
+        const summary = openings.find((op) => op.move === "*");
+        const moves = openings
+            .filter((op) => op.move !== "*")
+            .map((op) => ({
+                move: op.move,
+                games: op.white + op.draw + op.black,
+            }));
+        const gamesEndingHere = summary ? summary.white + summary.draw + summary.black : 0;
+        const gamesContinuing = moves.reduce((acc, m) => acc + m.games, 0);
+        return { moves, total: gamesEndingHere + gamesContinuing };
+    } catch {
+        return { moves: [], total: 0 };
+    }
+}
+
+interface BoardCoverageInput {
+    dbMoves: { move: string; games: number }[];
+    total: number;
+    minGames: number;
+    isUserTurn: boolean;
+    movesMap: Map<string, string>; // SAN → next board FEN
+    getChildCoverage: (nextFen: string) => Promise<{ coverage: number; missing: number }>;
+}
+
+async function computeBoardCoverage(
+    input: BoardCoverageInput,
+): Promise<{ coverage: number; missing: number }> {
+    const { dbMoves, total, minGames, isUserTurn, movesMap, getChildCoverage } = input;
+
+    if (total < minGames) {
+        return { coverage: 1, missing: 0 };
+    }
+
+    if (isUserTurn) {
+        if (movesMap.size === 0) {
+            return { coverage: 0, missing: total };
+        }
+        let maxCoverage = 0;
+        for (const nextFen of movesMap.values()) {
+            const { coverage } = await getChildCoverage(nextFen);
+            maxCoverage = Math.max(maxCoverage, coverage);
+        }
+        return { coverage: maxCoverage, missing: 0 };
+    }
+
+    // Opponent’s turn
+    const significant = dbMoves.filter((m) => m.games >= minGames);
+    const sigTotal = significant.reduce((sum, m) => sum + m.games, 0);
+    if (sigTotal === 0) {
+        return { coverage: 1, missing: 0 };
+    }
+
+    let weighted = 0;
+    let maxMissing = 0;
+    for (const m of significant) {
+        const freq = m.games / sigTotal;
+        if (movesMap.has(m.move)) {
+            const { coverage } = await getChildCoverage(movesMap.get(m.move)!);
+            weighted += freq * coverage;
+        } else if (m.games > maxMissing) {
+            maxMissing = m.games;
+        }
+    }
+    return { coverage: weighted, missing: maxMissing };
+}
+
+function createCoverageCalculator(
+    dbPath: string,
+    minGames: number,
+    orientation: "white" | "black",
+    stateMoves: Map<string, Map<string, string>>,
+) {
+    const dbCache = new Map<
+        string,
+        Promise<{ moves: { move: string; games: number }[]; total: number }>
+    >();
+    const boardCache = new Map<string, Promise<{ coverage: number; missing: number }>>();
+    const computing = new Set<string>();
+
+    const getDbMoves = (fen: string) => {
+        if (!dbCache.has(fen)) dbCache.set(fen, fetchPositionMoves(dbPath, fen));
+        return dbCache.get(fen)!;
+    };
+
+    const computeBoardStateCoverage = async (
+        boardFen: string,
+    ): Promise<{ coverage: number; missing: number }> => {
+        if (boardCache.has(boardFen)) return boardCache.get(boardFen)!;
+        if (computing.has(boardFen)) {
+            return { coverage: 1, missing: 0 };
+        }
+
+        computing.add(boardFen);
+        const promise = (async () => {
+            try {
+                const { moves: dbMoves, total } = await getDbMoves(boardFen);
+                const sideToMove = boardFen.split(" ")[1];
+                const isUserTurn = sideToMove === orientation[0];
+                const movesMap = stateMoves.get(boardFen) ?? new Map();
+
+                return computeBoardCoverage({
+                    dbMoves,
+                    total,
+                    minGames,
+                    isUserTurn,
+                    movesMap,
+                    getChildCoverage: computeBoardStateCoverage, // recursive but cached
+                });
+            } finally {
+                computing.delete(boardFen);
+            }
+        })();
+
+        boardCache.set(boardFen, promise);
+        return promise;
+    };
+
+    return { computeBoardStateCoverage, getDbMoves };
+}
+
+async function populateCoverageMaps(
+    root: TreeNode,
+    startPath: number[],
+    calculator: ReturnType<typeof createCoverageCalculator>,
+) {
+    const coverageMap = new Map<string, number>();
+    const gamesMap = new Map<string, number>();
+    const missingMap = new Map<string, number>();
+
+    async function walk(node: TreeNode, path: number[]) {
+        const boardFen = getBoardState(node.fen);
+        const { coverage, missing } = await calculator.computeBoardStateCoverage(boardFen);
+        const total = (await calculator.getDbMoves(boardFen)).total;
+        const key = path.join(",");
+
+        coverageMap.set(key, coverage);
+        missingMap.set(key, missing);
+        gamesMap.set(key, total);
+
+        for (let i = 0; i < node.children.length; i++) {
+            await walk(node.children[i], [...path, i]);
+        }
+    }
+
+    const startNode = getNodeAtPath(root, startPath);
+    if (startNode) await walk(startNode, startPath);
+
+    return { coverageMap, gamesMap, missingGamesMap: missingMap };
+}
 
 export async function computeTreeCoverage(
     root: TreeNode,
     userColor: "white" | "black",
     dbPath: string,
     minGames: number,
-    startPath: number[] = [],
+    startPath: number[],
+    stateMoves: Map<string, Map<string, string>>,
 ): Promise<{
     coverageMap: Map<string, number>;
     gamesMap: Map<string, number>;
     missingGamesMap: Map<string, number>;
 }> {
-    const userParity = userColor === "white" ? 0 : 1;
-    const coverageMap = new Map<string, number>();
-    const gamesMap = new Map<string, number>();
-    const missingGamesMap = new Map<string, number>();
-    const fenCoverageCache = new Map<string, Promise<number>>();
-    const fenMissingCache = new Map<string, number>();
-
-    async function getDbMoves(
-        fen: string,
-    ): Promise<{ moves: { move: string; games: number }[]; total: number }> {
-        try {
-            const [openings] = await searchPosition(
-                {
-                    path: dbPath,
-                    type: "exact",
-                    fen,
-                    color: "white",
-                    player: null,
-                    result: "any",
-                } as LocalOptions,
-                "coverage-calc",
-            );
-
-            const summary = openings.find((op) => op.move === "*");
-            const moves = openings
-                .filter((op) => op.move !== "*")
-                .map((op) => ({
-                    move: op.move,
-                    games: op.white + op.draw + op.black,
-                }));
-
-            const gamesEndingHere = summary ? summary.white + summary.draw + summary.black : 0;
-
-            const gamesContinuing = moves.reduce((acc, m) => acc + m.games, 0);
-
-            const total = gamesEndingHere + gamesContinuing;
-
-            return { moves, total };
-        } catch {
-            return { moves: [], total: 0 };
-        }
-    }
-
-    async function compute(node: TreeNode, path: number[]): Promise<number> {
-        const pathKey = path.join(",");
-
-        if (node.children.length === 0 && fenCoverageCache.has(node.fen)) {
-            const transpositionCoverage = await fenCoverageCache.get(node.fen)!;
-            coverageMap.set(pathKey, transpositionCoverage);
-            const { total: totalGames } = await getDbMoves(node.fen);
-            gamesMap.set(pathKey, totalGames);
-            missingGamesMap.set(pathKey, fenMissingCache.get(node.fen) ?? 0);
-            return transpositionCoverage;
-        }
-
-        if (node.children.length > 0 && !fenCoverageCache.has(node.fen)) {
-            const promise = computeNode(node, path);
-            fenCoverageCache.set(node.fen, promise);
-            return promise;
-        }
-
-        return computeNode(node, path);
-    }
-
-    async function computeNode(node: TreeNode, path: number[]): Promise<number> {
-        const pathKey = path.join(",");
-
-        const { moves: dbMoves, total: totalGames } = await getDbMoves(node.fen);
-        gamesMap.set(pathKey, totalGames);
-
-        if (totalGames < minGames) {
-            coverageMap.set(pathKey, 1);
-            missingGamesMap.set(pathKey, 0);
-            fenMissingCache.set(node.fen, 0);
-            return 1;
-        }
-
-        const isOpponentTurn = node.halfMoves % 2 !== userParity;
-
-        if (isOpponentTurn) {
-            if (node.children.length === 0) {
-                const partialCoverage = Math.min(minGames / totalGames, 1);
-                coverageMap.set(pathKey, partialCoverage);
-                const maxMissing = dbMoves
-                    .filter((m) => m.games >= minGames)
-                    .reduce((max, m) => Math.max(max, m.games), 0);
-                missingGamesMap.set(pathKey, maxMissing);
-                fenMissingCache.set(node.fen, maxMissing);
-                return partialCoverage;
-            }
-            const significantMoves = dbMoves.filter((m) => m.games >= minGames);
-            const significantTotal = significantMoves.reduce((acc, m) => acc + m.games, 0);
-
-            if (significantTotal === 0) {
-                coverageMap.set(pathKey, 1);
-                missingGamesMap.set(pathKey, 0);
-                fenMissingCache.set(node.fen, 0);
-                return 1;
-            }
-
-            let coverage = 0;
-            let maxMissingChildGames = 0;
-            for (const dbMove of significantMoves) {
-                const childIdx = node.children.findIndex((c) => c.san === dbMove.move);
-                if (childIdx !== -1) {
-                    const frequency = dbMove.games / significantTotal;
-                    const childCoverage = await compute(node.children[childIdx], [
-                        ...path,
-                        childIdx,
-                    ]);
-                    coverage += frequency * childCoverage;
-                } else {
-                    if (dbMove.games > maxMissingChildGames) {
-                        maxMissingChildGames = dbMove.games;
-                    }
-                }
-            }
-            coverageMap.set(pathKey, coverage);
-            missingGamesMap.set(pathKey, maxMissingChildGames);
-            fenMissingCache.set(node.fen, maxMissingChildGames);
-            return coverage;
-        }
-        if (node.children.length === 0) {
-            coverageMap.set(pathKey, 0);
-            missingGamesMap.set(pathKey, totalGames);
-            fenMissingCache.set(node.fen, totalGames);
-            return 0;
-        }
-        const childCoverage = await compute(node.children[0], [...path, 0]);
-        coverageMap.set(pathKey, childCoverage);
-        missingGamesMap.set(pathKey, 0);
-        fenMissingCache.set(node.fen, 0);
-        return childCoverage;
-    }
-
-    const startNode = getNodeAtPath(root, startPath);
-    await compute(startNode, startPath);
-    return { coverageMap, gamesMap, missingGamesMap };
+    const calculator = createCoverageCalculator(dbPath, minGames, userColor, stateMoves);
+    return populateCoverageMaps(root, startPath, calculator);
 }
 
 export function findNextGap(

--- a/src/utils/repertoire.ts
+++ b/src/utils/repertoire.ts
@@ -53,156 +53,180 @@ export async function fetchPositionMoves(
     }
 }
 
-interface BoardCoverageInput {
-    dbMoves: { move: string; games: number }[];
-    total: number;
-    minGames: number;
-    isUserTurn: boolean;
-    movesMap: Map<string, string>; // SAN → next board FEN
-    getChildCoverage: (nextFen: string) => Promise<{ coverage: number; missing: number }>;
-}
-
-async function computeBoardCoverage(
-    input: BoardCoverageInput,
-): Promise<{ coverage: number; missing: number }> {
-    const { dbMoves, total, minGames, isUserTurn, movesMap, getChildCoverage } = input;
-
-    if (total < minGames) {
-        return { coverage: 1, missing: 0 };
-    }
-
-    if (isUserTurn) {
-        if (movesMap.size === 0) {
-            return { coverage: 0, missing: total };
-        }
-        let maxCoverage = 0;
-        for (const nextFen of movesMap.values()) {
-            const { coverage } = await getChildCoverage(nextFen);
-            maxCoverage = Math.max(maxCoverage, coverage);
-        }
-        return { coverage: maxCoverage, missing: 0 };
-    }
-
-    // Opponent’s turn
-    const significant = dbMoves.filter((m) => m.games >= minGames);
-    const sigTotal = significant.reduce((sum, m) => sum + m.games, 0);
-    if (sigTotal === 0) {
-        return { coverage: 1, missing: 0 };
-    }
-
-    let weighted = 0;
-    let maxMissing = 0;
-    for (const m of significant) {
-        const freq = m.games / sigTotal;
-        if (movesMap.has(m.move)) {
-            const { coverage } = await getChildCoverage(movesMap.get(m.move)!);
-            weighted += freq * coverage;
-        } else if (m.games > maxMissing) {
-            maxMissing = m.games;
-        }
-    }
-    return { coverage: weighted, missing: maxMissing };
-}
-
-function createCoverageCalculator(
-    dbPath: string,
-    minGames: number,
-    orientation: "white" | "black",
-    stateMoves: Map<string, Map<string, string>>,
-) {
-    const dbCache = new Map<
-        string,
-        Promise<{
-            moves: { move: string; white: number; draw: number; black: number }[];
-            total: number;
-        }>
-    >();
-    const boardCache = new Map<string, Promise<{ coverage: number; missing: number }>>();
-    const computing = new Set<string>();
-
-    const getDbMoves = (
-        fen: string,
-    ): Promise<{
+type DbCache = Map<
+    string,
+    {
         moves: { move: string; white: number; draw: number; black: number }[];
         total: number;
-    }> => {
-        if (!dbCache.has(fen)) dbCache.set(fen, fetchPositionMoves(dbPath, fen));
-        return dbCache.get(fen)!;
-    };
+    }
+>;
 
-    const computeBoardStateCoverage = async (
-        boardFen: string,
-    ): Promise<{ coverage: number; missing: number }> => {
-        if (boardCache.has(boardFen)) return boardCache.get(boardFen)!;
-        if (computing.has(boardFen)) {
-            return { coverage: 1, missing: 0 };
-        }
+async function buildDbCache(root: TreeNode, startPath: number[], dbPath: string): Promise<DbCache> {
+    const startNode = startPath.length > 0 ? getNodeAtPath(root, startPath) : root;
 
-        computing.add(boardFen);
-        const promise = (async () => {
-            try {
-                const { moves: enrichedMoves, total } = await getDbMoves(boardFen);
-                const dbMoves = enrichedMoves.map((m) => ({
-                    move: m.move,
-                    games: m.white + m.draw + m.black,
-                }));
-                const sideToMove = boardFen.split(" ")[1];
-                const isUserTurn = sideToMove === orientation[0];
-                const movesMap = stateMoves.get(boardFen) ?? new Map();
+    const fenSet = new Set<string>();
+    const stack: TreeNode[] = [startNode];
+    while (stack.length > 0) {
+        const node = stack.pop()!;
+        fenSet.add(getBoardState(node.fen));
+        for (const child of node.children) stack.push(child);
+    }
+    const fenList = [...fenSet];
 
-                return computeBoardCoverage({
-                    dbMoves,
-                    total,
-                    minGames,
-                    isUserTurn,
-                    movesMap,
-                    getChildCoverage: computeBoardStateCoverage,
-                });
-            } finally {
-                computing.delete(boardFen);
-            }
-        })();
+    const cache: DbCache = new Map();
 
-        boardCache.set(boardFen, promise);
-        return promise;
-    };
+    for (let i = 0; i < fenList.length; i++) {
+        const fen = fenList[i];
+        const data = await fetchPositionMoves(dbPath, fen);
 
-    return { computeBoardStateCoverage, getDbMoves };
+        const enrichedMoves = data.moves.map((m) => ({
+            move: m.move,
+            white: m.white,
+            draw: m.draw,
+            black: m.black,
+        }));
+        const total = data.total;
+        cache.set(fen, { moves: enrichedMoves, total });
+    }
+    return cache;
 }
 
-async function populateCoverageMaps(
+/**
+ * Compute coverage and missing games for a single board FEN.
+ * Recurses into child FENs (which must already be in dbCache and stateMoves).
+ * Results are stored in a Map so each FEN is processed only once.
+ */
+function computeCoverageForFen(
+    fen: string,
+    dbCache: DbCache,
+    stateMoves: Map<string, Map<string, string>>,
+    orientation: "white" | "black",
+    minGames: number,
+    memo: Map<string, { coverage: number; missing: number }>,
+): { coverage: number; missing: number } {
+    const cached = memo.get(fen);
+    if (cached) return cached;
+
+    const dbData = dbCache.get(fen);
+    const moves = dbData?.moves ?? [];
+    const total = dbData?.total ?? 0;
+
+    if (total < minGames) {
+        const res = { coverage: 1, missing: 0 };
+        memo.set(fen, res);
+        return res;
+    }
+
+    const sideToMove = fen.split(" ")[1]; // "w" or "b"
+    const isUserTurn = sideToMove === orientation[0];
+
+    if (isUserTurn) {
+        const childFenMap = stateMoves.get(fen);
+        if (!childFenMap || childFenMap.size === 0) {
+            const res = { coverage: 0, missing: total };
+            memo.set(fen, res);
+            return res;
+        }
+        let maxCoverage = 0;
+        for (const childFen of childFenMap.values()) {
+            const child = computeCoverageForFen(
+                childFen,
+                dbCache,
+                stateMoves,
+                orientation,
+                minGames,
+                memo,
+            );
+            maxCoverage = Math.max(maxCoverage, child.coverage);
+        }
+        const res = { coverage: maxCoverage, missing: 0 };
+        memo.set(fen, res);
+        return res;
+    } else {
+        // Opponent's turn
+        const significant = moves.filter((m) => m.white + m.draw + m.black >= minGames);
+        const sigTotal = significant.reduce((sum, m) => sum + m.white + m.draw + m.black, 0);
+        if (sigTotal === 0) {
+            const res = { coverage: 1, missing: 0 };
+            memo.set(fen, res);
+            return res;
+        }
+        let weighted = 0;
+        let maxMissing = 0;
+        for (const m of significant) {
+            const freq = (m.white + m.draw + m.black) / sigTotal;
+            const childFen = stateMoves.get(fen)?.get(m.move);
+            if (childFen) {
+                const child = computeCoverageForFen(
+                    childFen,
+                    dbCache,
+                    stateMoves,
+                    orientation,
+                    minGames,
+                    memo,
+                );
+                weighted += freq * child.coverage;
+            } else {
+                if (m.white + m.draw + m.black > maxMissing) {
+                    maxMissing = m.white + m.draw + m.black;
+                }
+            }
+        }
+        const res = { coverage: weighted, missing: maxMissing };
+        memo.set(fen, res);
+        return res;
+    }
+}
+
+/**
+ * Walk the actual tree and build the path‑keyed maps needed by the UI.
+ */
+function buildPathMaps(
     root: TreeNode,
     startPath: number[],
-    calculator: ReturnType<typeof createCoverageCalculator>,
-) {
+    fenCoverageCache: Map<string, { coverage: number; missing: number }>,
+    dbCache: DbCache,
+): {
+    coverageMap: Map<string, number>;
+    gamesMap: Map<string, number>;
+    missingGamesMap: Map<string, number>;
+    dbMovesMap: Map<
+        string,
+        { moves: { move: string; white: number; draw: number; black: number }[]; total: number }
+    >;
+} {
     const coverageMap = new Map<string, number>();
     const gamesMap = new Map<string, number>();
-    const missingMap = new Map<string, number>();
+    const missingGamesMap = new Map<string, number>();
     const dbMovesMap = new Map<
         string,
         { moves: { move: string; white: number; draw: number; black: number }[]; total: number }
     >();
 
-    async function walk(node: TreeNode, path: number[]) {
+    const startNode = startPath.length > 0 ? getNodeAtPath(root, startPath) : root;
+    function walk(node: TreeNode, path: number[]) {
         const boardFen = getBoardState(node.fen);
-        const { coverage, missing } = await calculator.computeBoardStateCoverage(boardFen);
-        const { moves, total } = await calculator.getDbMoves(boardFen);
-        const key = path.join(",");
-
-        coverageMap.set(key, coverage);
-        missingMap.set(key, missing);
-        gamesMap.set(key, total);
-        dbMovesMap.set(boardFen, { moves, total });
-
+        const fenData = fenCoverageCache.get(boardFen);
+        if (fenData) {
+            const key = path.join(",");
+            coverageMap.set(key, fenData.coverage);
+            missingGamesMap.set(key, fenData.missing);
+        }
+        const dbData = dbCache.get(boardFen);
+        if (dbData) {
+            const key = path.join(",");
+            gamesMap.set(key, dbData.total);
+            if (!dbMovesMap.has(boardFen)) {
+                dbMovesMap.set(boardFen, dbData);
+            }
+        }
         for (let i = 0; i < node.children.length; i++) {
-            await walk(node.children[i], [...path, i]);
+            walk(node.children[i], [...path, i]);
         }
     }
+    walk(startNode, [...startPath]);
 
-    const startNode = getNodeAtPath(root, startPath);
-    if (startNode) await walk(startNode, startPath);
-
-    return { coverageMap, gamesMap, missingGamesMap: missingMap, dbMovesMap };
+    return { coverageMap, gamesMap, missingGamesMap, dbMovesMap };
 }
 
 export async function computeTreeCoverage(
@@ -221,8 +245,18 @@ export async function computeTreeCoverage(
         { moves: { move: string; white: number; draw: number; black: number }[]; total: number }
     >;
 }> {
-    const calculator = createCoverageCalculator(dbPath, minGames, userColor, stateMoves);
-    return populateCoverageMaps(root, startPath, calculator);
+    const dbCache = await buildDbCache(root, startPath, dbPath);
+
+    const memo = new Map<string, { coverage: number; missing: number }>();
+    let computedCount = 0;
+    for (const fen of dbCache.keys()) {
+        computeCoverageForFen(fen, dbCache, stateMoves, userColor, minGames, memo);
+        computedCount++;
+    }
+
+    const pathMaps = buildPathMaps(root, startPath, memo, dbCache);
+
+    return pathMaps;
 }
 
 export function findNextGap(

--- a/src/utils/repertoire.ts
+++ b/src/utils/repertoire.ts
@@ -1,7 +1,7 @@
 import type { LocalOptions } from "@/components/panels/database/DatabasePanel";
 import { searchPosition } from "./db";
-import { getNodeAtPath, type TreeNode, treeIterator } from "./treeReducer";
-import { getBoardState, TreeStoreState } from "@/state/store/tree";
+import { getNodeAtPath, type TreeNode, treeIterator, getBoardState } from "./treeReducer";
+import { TreeStoreState } from "@/state/store/tree";
 import { memoize } from "proxy-memoize";
 
 export type PositionMove = {
@@ -17,10 +17,13 @@ export type PositionMove = {
     path: number[];
 };
 
-async function fetchPositionMoves(
+export async function fetchPositionMoves(
     dbPath: string,
     fen: string,
-): Promise<{ moves: { move: string; games: number }[]; total: number }> {
+): Promise<{
+    moves: { move: string; white: number; draw: number; black: number }[];
+    total: number;
+}> {
     try {
         const [openings] = await searchPosition(
             {
@@ -38,10 +41,12 @@ async function fetchPositionMoves(
             .filter((op) => op.move !== "*")
             .map((op) => ({
                 move: op.move,
-                games: op.white + op.draw + op.black,
+                white: op.white,
+                draw: op.draw,
+                black: op.black,
             }));
         const gamesEndingHere = summary ? summary.white + summary.draw + summary.black : 0;
-        const gamesContinuing = moves.reduce((acc, m) => acc + m.games, 0);
+        const gamesContinuing = moves.reduce((acc, m) => acc + m.white + m.draw + m.black, 0);
         return { moves, total: gamesEndingHere + gamesContinuing };
     } catch {
         return { moves: [], total: 0 };
@@ -107,12 +112,20 @@ function createCoverageCalculator(
 ) {
     const dbCache = new Map<
         string,
-        Promise<{ moves: { move: string; games: number }[]; total: number }>
+        Promise<{
+            moves: { move: string; white: number; draw: number; black: number }[];
+            total: number;
+        }>
     >();
     const boardCache = new Map<string, Promise<{ coverage: number; missing: number }>>();
     const computing = new Set<string>();
 
-    const getDbMoves = (fen: string) => {
+    const getDbMoves = (
+        fen: string,
+    ): Promise<{
+        moves: { move: string; white: number; draw: number; black: number }[];
+        total: number;
+    }> => {
         if (!dbCache.has(fen)) dbCache.set(fen, fetchPositionMoves(dbPath, fen));
         return dbCache.get(fen)!;
     };
@@ -128,7 +141,11 @@ function createCoverageCalculator(
         computing.add(boardFen);
         const promise = (async () => {
             try {
-                const { moves: dbMoves, total } = await getDbMoves(boardFen);
+                const { moves: enrichedMoves, total } = await getDbMoves(boardFen);
+                const dbMoves = enrichedMoves.map((m) => ({
+                    move: m.move,
+                    games: m.white + m.draw + m.black,
+                }));
                 const sideToMove = boardFen.split(" ")[1];
                 const isUserTurn = sideToMove === orientation[0];
                 const movesMap = stateMoves.get(boardFen) ?? new Map();
@@ -139,7 +156,7 @@ function createCoverageCalculator(
                     minGames,
                     isUserTurn,
                     movesMap,
-                    getChildCoverage: computeBoardStateCoverage, // recursive but cached
+                    getChildCoverage: computeBoardStateCoverage,
                 });
             } finally {
                 computing.delete(boardFen);
@@ -161,16 +178,21 @@ async function populateCoverageMaps(
     const coverageMap = new Map<string, number>();
     const gamesMap = new Map<string, number>();
     const missingMap = new Map<string, number>();
+    const dbMovesMap = new Map<
+        string,
+        { moves: { move: string; white: number; draw: number; black: number }[]; total: number }
+    >();
 
     async function walk(node: TreeNode, path: number[]) {
         const boardFen = getBoardState(node.fen);
         const { coverage, missing } = await calculator.computeBoardStateCoverage(boardFen);
-        const total = (await calculator.getDbMoves(boardFen)).total;
+        const { moves, total } = await calculator.getDbMoves(boardFen);
         const key = path.join(",");
 
         coverageMap.set(key, coverage);
         missingMap.set(key, missing);
         gamesMap.set(key, total);
+        dbMovesMap.set(boardFen, { moves, total });
 
         for (let i = 0; i < node.children.length; i++) {
             await walk(node.children[i], [...path, i]);
@@ -180,7 +202,7 @@ async function populateCoverageMaps(
     const startNode = getNodeAtPath(root, startPath);
     if (startNode) await walk(startNode, startPath);
 
-    return { coverageMap, gamesMap, missingGamesMap: missingMap };
+    return { coverageMap, gamesMap, missingGamesMap: missingMap, dbMovesMap };
 }
 
 export async function computeTreeCoverage(
@@ -194,6 +216,10 @@ export async function computeTreeCoverage(
     coverageMap: Map<string, number>;
     gamesMap: Map<string, number>;
     missingGamesMap: Map<string, number>;
+    dbMovesMap: Map<
+        string,
+        { moves: { move: string; white: number; draw: number; black: number }[]; total: number }
+    >;
 }> {
     const calculator = createCoverageCalculator(dbPath, minGames, userColor, stateMoves);
     return populateCoverageMaps(root, startPath, calculator);
@@ -288,10 +314,10 @@ export function findBiggestGap(
             if (isGap) {
                 if (missing > maxMissing) {
                     maxMissing = missing;
-                    bestPath = path;
+                    bestPath = [...path];
                 } else if (missing === maxMissing && bestPath !== null) {
                     if (path.length < bestPath.length) {
-                        bestPath = path;
+                        bestPath = [...path];
                     }
                 }
             }

--- a/src/utils/tests/store.test.ts
+++ b/src/utils/tests/store.test.ts
@@ -6,7 +6,7 @@ import { buildTranspositionMaps, defaultTree, TreeNode, type TreeState } from "@
 const store = createTreeStore();
 
 beforeEach(() => {
-    store.setState(defaultTree());
+    store.getState().setState(defaultTree());
 });
 
 const e4 = parseUci("e2e4")!;
@@ -160,7 +160,7 @@ test("should handle setState", () => {
 });
 
 test("should handle reset", () => {
-    store.setState(treeE4D5());
+    store.getState().setState(treeE4D5());
     store.getState().reset();
     expect(getNewState()).toStrictEqual({
         ...defaultTree(),
@@ -257,7 +257,7 @@ test("should handle makeMoves", () => {
 });
 
 test("should handle goToStart", () => {
-    store.setState(treeE4D5());
+    store.getState().setState(treeE4D5());
     store.getState().goToStart();
 
     expect(getNewState()).toStrictEqual({
@@ -268,7 +268,7 @@ test("should handle goToStart", () => {
 });
 
 test("should handle goToEnd", () => {
-    store.setState({ ...treeE4D5(), position: [] });
+    store.getState().setState({ ...treeE4D5(), position: [] });
     store.getState().goToEnd();
 
     expect(getNewState()).toStrictEqual({
@@ -279,7 +279,7 @@ test("should handle goToEnd", () => {
 });
 
 test("should handle goToNext", () => {
-    store.setState({ ...treeE4D5(), position: [] });
+    store.getState().setState({ ...treeE4D5(), position: [] });
     store.getState().goToNext();
 
     expect(getNewState()).toStrictEqual({
@@ -290,7 +290,7 @@ test("should handle goToNext", () => {
 });
 
 test("should handle goToPrevious", () => {
-    store.setState({ ...treeE4D5(), position: [0] });
+    store.getState().setState({ ...treeE4D5(), position: [0] });
     store.getState().goToPrevious();
 
     expect(getNewState()).toStrictEqual({
@@ -301,7 +301,7 @@ test("should handle goToPrevious", () => {
 });
 
 test("should handle goToBranchEnd", () => {
-    store.setState({ ...treeE4D5(), position: [] });
+    store.getState().setState({ ...treeE4D5(), position: [] });
     store.getState().goToBranchEnd();
 
     expect(getNewState()).toStrictEqual({
@@ -312,7 +312,7 @@ test("should handle goToBranchEnd", () => {
 });
 
 test("should handle goToBranchStart", () => {
-    store.setState({ ...treeE4D5(), position: [0, 0] });
+    store.getState().setState({ ...treeE4D5(), position: [0, 0] });
     store.getState().goToBranchStart();
 
     expect(getNewState()).toStrictEqual({
@@ -323,7 +323,7 @@ test("should handle goToBranchStart", () => {
 });
 
 test("should handle goToMove", () => {
-    store.setState({ ...treeE4D5(), position: [] });
+    store.getState().setState({ ...treeE4D5(), position: [] });
     store.getState().goToMove([0]);
 
     expect(getNewState()).toStrictEqual({
@@ -334,7 +334,7 @@ test("should handle goToMove", () => {
 });
 
 test("should handle deleteMove", () => {
-    store.setState(treeE4D5());
+    store.getState().setState(treeE4D5());
     store.getState().deleteMove([0]);
 
     expect(getNewState()).toStrictEqual({
@@ -345,7 +345,7 @@ test("should handle deleteMove", () => {
 });
 
 test("should handle setAnnotation", () => {
-    store.setState({ ...treeE4D5(), position: [0] });
+    store.getState().setState({ ...treeE4D5(), position: [0] });
     store.getState().setAnnotation("!");
 
     const mutatedRoot: TreeNode = {
@@ -368,7 +368,7 @@ test("should handle setAnnotation", () => {
 });
 
 test("should handle setComment", () => {
-    store.setState({ ...treeE4D5(), position: [0] });
+    store.getState().setState({ ...treeE4D5(), position: [0] });
     store.getState().setComment("test");
 
     const mutatedRoot: TreeNode = {
@@ -391,7 +391,7 @@ test("should handle setComment", () => {
 });
 
 test("should handle setFen", () => {
-    store.setState({ ...treeE4D5(), position: [0] });
+    store.getState().setState({ ...treeE4D5(), position: [0] });
     store.getState().setFen("rnbq1bnr/ppppkppp/8/4p3/4P3/8/PPPPKPPP/RNBQ1BNR w - - 2 3");
 
     const newRoot = {
@@ -407,7 +407,7 @@ test("should handle setFen", () => {
 });
 
 test("should handle setScore", () => {
-    store.setState({ ...treeE4D5(), position: [0] });
+    store.getState().setState({ ...treeE4D5(), position: [0] });
     store.getState().setScore({
         value: { type: "mate" as const, value: 1 },
         wdl: null,
@@ -436,7 +436,7 @@ test("should handle setScore", () => {
 });
 
 test("should handle setShapes", () => {
-    store.setState({ ...treeE4D5(), position: [0] });
+    store.getState().setState({ ...treeE4D5(), position: [0] });
     store.getState().setShapes([{ brush: "red", orig: "e4", dest: "d5" }]);
 
     const mutatedRoot: TreeNode = {
@@ -459,7 +459,7 @@ test("should handle setShapes", () => {
 });
 
 test("should handle addAnalysis", () => {
-    store.setState({ ...treeE4D5(), position: [0] });
+    store.getState().setState({ ...treeE4D5(), position: [0] });
     store.getState().addAnalysis([
         {
             best: [
@@ -530,7 +530,7 @@ test("should handle addAnalysis", () => {
     });
 });
 test("should handle promoteVariation", () => {
-    store.setState(treeE4D5Nf3());
+    store.getState().setState(treeE4D5Nf3());
     store.getState().promoteVariation([1]);
 
     expect(getNewState()).toStrictEqual({

--- a/src/utils/tests/store.test.ts
+++ b/src/utils/tests/store.test.ts
@@ -561,3 +561,350 @@ test("should handle promoteVariation", () => {
         }),
     });
 });
+
+// Helper to build a simple transposition tree:
+// 1. e4 e5 2. Nf3 Nc6 (main line with children)
+// and a side line 1. Nf3 Nc6 2. e4 e5 transposing to the same position after move 2.
+const e4Move = parseUci("e2e4")!;
+const e5Move = parseUci("e7e5")!;
+const Nf3Move = parseUci("g1f3")!;
+const Nc6Move = parseUci("b8c6")!;
+
+const buildTranspositionTree = () => {
+    const root: TreeNode = {
+        ...defaultTree().root,
+        children: [],
+    };
+
+    // Main line: e4 e5 Nf3 Nc6
+    const e4Node: TreeNode = {
+        fen: "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
+        move: e4Move,
+        san: "e4",
+        children: [],
+        score: null,
+        depth: null,
+        halfMoves: 1,
+        shapes: [],
+        annotations: [],
+        comment: "",
+    };
+    const e5Node: TreeNode = {
+        fen: "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
+        move: e5Move,
+        san: "e5",
+        children: [],
+        score: null,
+        depth: null,
+        halfMoves: 2,
+        shapes: [],
+        annotations: [],
+        comment: "",
+    };
+    const Nf3NodeMain: TreeNode = {
+        fen: "rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
+        move: Nf3Move,
+        san: "Nf3",
+        children: [],
+        score: null,
+        depth: null,
+        halfMoves: 3,
+        shapes: [],
+        annotations: [],
+        comment: "",
+    };
+    const Nc6NodeMain: TreeNode = {
+        fen: "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",
+        move: Nc6Move,
+        san: "Nc6",
+        children: [
+            {
+                fen: "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3", // same fen but after playing? Actually need to be a child of Nc6: for simplicity, we'll just give it a child so it has children
+                move: parseUci("f1b5")!,
+                san: "Bb5",
+                children: [],
+                score: null,
+                depth: null,
+                halfMoves: 4,
+                shapes: [],
+                annotations: [],
+                comment: "",
+            },
+        ],
+        score: null,
+        depth: null,
+        halfMoves: 4,
+        shapes: [],
+        annotations: [],
+        comment: "",
+    };
+
+    // Side line: Nf3 Nc6 e4 e5 transposing
+    const Nf3NodeSide: TreeNode = {
+        fen: "rnbqkbnr/pppppppp/8/8/8/5N2/PPPPPPPP/RNBQKB1R b KQkq - 1 1",
+        move: Nf3Move,
+        san: "Nf3",
+        children: [],
+        score: null,
+        depth: null,
+        halfMoves: 1,
+        shapes: [],
+        annotations: [],
+        comment: "",
+    };
+    const Nc6NodeSide: TreeNode = {
+        fen: "r1bqkbnr/pppppppp/2n5/8/8/5N2/PPPPPPPP/RNBQKB1R w KQkq - 2 2",
+        move: Nc6Move,
+        san: "Nc6",
+        children: [],
+        score: null,
+        depth: null,
+        halfMoves: 2,
+        shapes: [],
+        annotations: [],
+        comment: "",
+    };
+    const e4NodeSide: TreeNode = {
+        fen: "r1bqkbnr/pppppppp/2n5/8/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 0 2", // after e4
+        move: e4Move,
+        san: "e4",
+        children: [],
+        score: null,
+        depth: null,
+        halfMoves: 3,
+        shapes: [],
+        annotations: [],
+        comment: "",
+    };
+    const e5NodeSide: TreeNode = {
+        fen: "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 0 3",
+        move: e5Move,
+        san: "e5",
+        children: [], // this is the transposition node, has no children in side line
+        score: null,
+        depth: null,
+        halfMoves: 4,
+        shapes: [],
+        annotations: [],
+        comment: "",
+    };
+
+    // connect main line
+    e4Node.children = [e5Node];
+    e5Node.children = [Nf3NodeMain];
+    Nf3NodeMain.children = [Nc6NodeMain];
+
+    // connect side line
+    Nf3NodeSide.children = [Nc6NodeSide];
+    Nc6NodeSide.children = [e4NodeSide];
+    e4NodeSide.children = [e5NodeSide];
+
+    // root has two branches: e4 (index 0) and Nf3 (index 1)
+    root.children = [e4Node, Nf3NodeSide];
+
+    return root;
+};
+
+test("goToNext transposition fallback: jump to transposition with children", () => {
+    const root = buildTranspositionTree();
+    store.getState().setState({
+        ...defaultTree(),
+        root,
+        position: [1, 0, 0, 0], // side line after 1. Nf3 Nc6 e4 e5 (node with no children)
+    });
+
+    store.getState().goToNext();
+
+    const state = getNewState();
+    // Should have jumped to the main line Nc6 node's first child
+    expect(state.position).toEqual([0, 0, 0, 0, 0]); // main line e4 e5 Nf3 Nc6 Bb5
+});
+
+test("goToNext transposition fallback: no fallback when no transposition has children", () => {
+    // Build a tree where a side line transposes but no node has children
+    const rootNoChildren = {
+        ...defaultTree().root,
+        children: [
+            {
+                fen: "start",
+                move: e4Move,
+                san: "e4",
+                children: [],
+                score: null,
+                depth: null,
+                halfMoves: 1,
+                shapes: [],
+                annotations: [],
+                comment: "",
+            },
+            {
+                fen: "start",
+                move: Nf3Move,
+                san: "Nf3",
+                children: [],
+                score: null,
+                depth: null,
+                halfMoves: 1,
+                shapes: [],
+                annotations: [],
+                comment: "",
+            },
+        ],
+    };
+    store.getState().setState({ ...defaultTree(), root: rootNoChildren, position: [1] });
+    const posBefore = store.getState().position;
+    store.getState().goToNext();
+    expect(store.getState().position).toEqual(posBefore); // no change
+});
+
+test("goToNext transposition fallback: lexicographic priority", () => {
+    // Shared board state: after 1. e4 e5 2. Nf3
+    const sharedFen = "rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2";
+
+    // Two nodes that HAVE children and share the same FEN (transposition targets)
+    const nodeWithChildA: TreeNode = {
+        fen: sharedFen,
+        move: Nf3Move,
+        san: "Nf3",
+        children: [
+            {
+                // Child gets a distinct but valid FEN
+                fen: "rnbqkb1r/pppp1ppp/5n2/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",
+                move: parseUci("b8c6")!,
+                san: "Nc6",
+                children: [],
+                score: null,
+                depth: null,
+                halfMoves: 3,
+                shapes: [],
+                annotations: [],
+                comment: "",
+            },
+        ],
+        score: null,
+        depth: null,
+        halfMoves: 2,
+        shapes: [],
+        annotations: [],
+        comment: "",
+    };
+    const nodeWithChildB: TreeNode = {
+        fen: sharedFen,
+        move: Nf3Move,
+        san: "Nf3",
+        children: [
+            {
+                fen: "rnbqkb1r/pppp1ppp/5n2/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 4 3", // different move counter makes it distinct but board state identical
+                move: parseUci("d2d4")!,
+                san: "d4",
+                children: [],
+                score: null,
+                depth: null,
+                halfMoves: 3,
+                shapes: [],
+                annotations: [],
+                comment: "",
+            },
+        ],
+        score: null,
+        depth: null,
+        halfMoves: 2,
+        shapes: [],
+        annotations: [],
+        comment: "",
+    };
+
+    // A third node that shares the FEN but has NO children.
+    // goToNext from here should trigger transposition fallback.
+    const nodeNoChild: TreeNode = {
+        fen: sharedFen,
+        move: Nf3Move,
+        san: "Nf3",
+        children: [],
+        score: null,
+        depth: null,
+        halfMoves: 2,
+        shapes: [],
+        annotations: [],
+        comment: "",
+    };
+
+    // Build tree:
+    // branch 0 -> nodeWithChildA (path [0,0])
+    // branch 1 -> nodeWithChildB (path [1,0])
+    // branch 2 -> nodeNoChild   (path [2,0])
+    const root: TreeNode = {
+        ...defaultTree().root,
+        children: [
+            {
+                fen: defaultTree().root.fen,
+                move: e4Move,
+                san: "e4",
+                children: [nodeWithChildA],
+                score: null,
+                depth: null,
+                halfMoves: 1,
+                shapes: [],
+                annotations: [],
+                comment: "",
+            },
+            {
+                fen: defaultTree().root.fen,
+                move: Nf3Move,
+                san: "Nf3",
+                children: [nodeWithChildB],
+                score: null,
+                depth: null,
+                halfMoves: 1,
+                shapes: [],
+                annotations: [],
+                comment: "",
+            },
+            {
+                fen: defaultTree().root.fen,
+                move: parseUci("d2d4")!,
+                san: "d4",
+                children: [nodeNoChild],
+                score: null,
+                depth: null,
+                halfMoves: 1,
+                shapes: [],
+                annotations: [],
+                comment: "",
+            },
+        ],
+    };
+
+    store.getState().setState({ ...defaultTree(), root, position: [2, 0] }); // start at nodeNoChild
+    store.getState().goToNext();
+    const state = getNewState();
+    // Should pick path [0,0] (nodeWithChildA) because it's lexicographically smaller than [1,0]
+    expect(state.position).toEqual([0, 0, 0]); // first child of nodeWithChildA
+});
+
+test("boardStateMap updates when start changes", () => {
+    store.getState().setState(treeE4D5());
+    store.getState().setStart([0]); // start at e4 node
+    const state = getNewState();
+    // The map should now only contain nodes from e4 onward
+    const entries = Object.values(state.boardStateMap);
+    // There should be at least one entry for the e4 node fen and its child
+    expect(entries.length).toBeGreaterThan(0);
+    // Make sure the root fen is not in the map (since start excludes it)
+    const rootFen = defaultTree().root.fen;
+    expect(state.boardStateMap[rootFen]).toBeUndefined();
+});
+
+test("practice mode: goToNext transposition fallback bypasses guard", () => {
+    const root = buildTranspositionTree();
+    store.getState().setState({
+        ...defaultTree(),
+        root,
+        position: [1, 0, 0, 0], // side line, no children
+    });
+    store.getState().setPracticePath([1, 0, 0, 0]); // end of drill
+
+    store.getState().goToNext();
+    const state = getNewState();
+    expect(state.position).toEqual([0, 0, 0, 0, 0]); // should jump to transposition child
+});

--- a/src/utils/tests/store.test.ts
+++ b/src/utils/tests/store.test.ts
@@ -1,7 +1,7 @@
 import { parseUci } from "chessops";
 import { beforeEach, expect, test } from "vitest";
 import { createTreeStore } from "@/state/store/tree";
-import { defaultTree, type TreeState } from "@/utils/treeReducer";
+import { buildTranspositionMaps, defaultTree, TreeNode, type TreeState } from "@/utils/treeReducer";
 
 const store = createTreeStore();
 
@@ -130,25 +130,42 @@ const getNewState = () => {
         report: {
             inProgress: false,
         },
+        boardStateMap: s.boardStateMap,
     };
 };
+
+// Helper to compute the expected boardStateMap for a given root and start path
+function expectedMap(root: TreeState["root"], start: number[] = []) {
+    return buildTranspositionMaps(root, start);
+}
 
 test("should handle save", () => {
     store.setState({ dirty: true });
     store.getState().save();
 
-    expect(getNewState()).toStrictEqual({ ...defaultTree(), dirty: false });
+    expect(getNewState()).toStrictEqual({
+        ...defaultTree(),
+        dirty: false,
+        boardStateMap: expectedMap(defaultTree().root),
+    });
 });
 
 test("should handle setState", () => {
-    store.getState().setState(treeE4D5());
-    expect(getNewState()).toStrictEqual(treeE4D5());
+    const state = treeE4D5();
+    store.getState().setState(state);
+    expect(getNewState()).toStrictEqual({
+        ...state,
+        boardStateMap: expectedMap(state.root),
+    });
 });
 
 test("should handle reset", () => {
     store.setState(treeE4D5());
     store.getState().reset();
-    expect(getNewState()).toStrictEqual(defaultTree());
+    expect(getNewState()).toStrictEqual({
+        ...defaultTree(),
+        boardStateMap: expectedMap(defaultTree().root),
+    });
 });
 
 test("should handle setHeaders", () => {
@@ -166,6 +183,7 @@ test("should handle setHeaders", () => {
             orientation: "black",
             start: [1],
         },
+        boardStateMap: expectedMap(defaultTree().root, [1]),
     });
 });
 
@@ -176,6 +194,7 @@ test("should handle setStart", () => {
         ...defaultTree(),
         dirty: true,
         headers: { ...defaultTree().headers, start: [1] },
+        boardStateMap: expectedMap(defaultTree().root, [1]),
     });
 });
 
@@ -204,16 +223,36 @@ test("should handle makeMove", () => {
                 },
             ],
         },
+        boardStateMap: expectedMap({
+            ...defaultTree().root,
+            children: [
+                {
+                    fen: "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1",
+                    move: e4,
+                    san: "e4",
+                    children: [],
+                    score: null,
+                    clock: undefined,
+                    depth: null,
+                    halfMoves: 1,
+                    shapes: [],
+                    annotations: [],
+                    comment: "",
+                },
+            ],
+        }),
     });
 });
 
 test("should handle makeMoves", () => {
     store.getState().makeMoves({ payload: ["e4", "d5"] });
 
+    const expectedTree = treeE4D5();
     expect(getNewState()).toStrictEqual({
-        ...treeE4D5(),
+        ...expectedTree,
         dirty: true,
         position: [0, 0],
+        boardStateMap: expectedMap(expectedTree.root),
     });
 });
 
@@ -224,6 +263,7 @@ test("should handle goToStart", () => {
     expect(getNewState()).toStrictEqual({
         ...treeE4D5(),
         position: [],
+        boardStateMap: expectedMap(treeE4D5().root),
     });
 });
 
@@ -234,6 +274,7 @@ test("should handle goToEnd", () => {
     expect(getNewState()).toStrictEqual({
         ...treeE4D5(),
         position: [0, 0],
+        boardStateMap: expectedMap(treeE4D5().root),
     });
 });
 
@@ -244,6 +285,7 @@ test("should handle goToNext", () => {
     expect(getNewState()).toStrictEqual({
         ...treeE4D5(),
         position: [0],
+        boardStateMap: expectedMap(treeE4D5().root),
     });
 });
 
@@ -254,6 +296,7 @@ test("should handle goToPrevious", () => {
     expect(getNewState()).toStrictEqual({
         ...treeE4D5(),
         position: [],
+        boardStateMap: expectedMap(treeE4D5().root),
     });
 });
 
@@ -264,6 +307,7 @@ test("should handle goToBranchEnd", () => {
     expect(getNewState()).toStrictEqual({
         ...treeE4D5(),
         position: [0, 0],
+        boardStateMap: expectedMap(treeE4D5().root),
     });
 });
 
@@ -274,6 +318,7 @@ test("should handle goToBranchStart", () => {
     expect(getNewState()).toStrictEqual({
         ...treeE4D5(),
         position: [],
+        boardStateMap: expectedMap(treeE4D5().root),
     });
 });
 
@@ -284,6 +329,7 @@ test("should handle goToMove", () => {
     expect(getNewState()).toStrictEqual({
         ...treeE4D5(),
         position: [0],
+        boardStateMap: expectedMap(treeE4D5().root),
     });
 });
 
@@ -291,26 +337,33 @@ test("should handle deleteMove", () => {
     store.setState(treeE4D5());
     store.getState().deleteMove([0]);
 
-    expect(getNewState()).toStrictEqual({ ...defaultTree(), dirty: true });
+    expect(getNewState()).toStrictEqual({
+        ...defaultTree(),
+        dirty: true,
+        boardStateMap: expectedMap(defaultTree().root),
+    });
 });
 
 test("should handle setAnnotation", () => {
     store.setState({ ...treeE4D5(), position: [0] });
     store.getState().setAnnotation("!");
 
+    const mutatedRoot: TreeNode = {
+        ...treeE4D5().root,
+        children: [
+            {
+                ...treeE4D5().root.children[0],
+                annotations: ["!"],
+            },
+        ],
+    };
+
     expect(getNewState()).toStrictEqual({
         ...treeE4D5(),
         dirty: true,
         position: [0],
-        root: {
-            ...treeE4D5().root,
-            children: [
-                {
-                    ...treeE4D5().root.children[0],
-                    annotations: ["!"],
-                },
-            ],
-        },
+        root: mutatedRoot,
+        boardStateMap: expectedMap(mutatedRoot),
     });
 });
 
@@ -318,19 +371,22 @@ test("should handle setComment", () => {
     store.setState({ ...treeE4D5(), position: [0] });
     store.getState().setComment("test");
 
+    const mutatedRoot: TreeNode = {
+        ...treeE4D5().root,
+        children: [
+            {
+                ...treeE4D5().root.children[0],
+                comment: "test",
+            },
+        ],
+    };
+
     expect(getNewState()).toStrictEqual({
         ...treeE4D5(),
         dirty: true,
         position: [0],
-        root: {
-            ...treeE4D5().root,
-            children: [
-                {
-                    ...treeE4D5().root.children[0],
-                    comment: "test",
-                },
-            ],
-        },
+        root: mutatedRoot,
+        boardStateMap: expectedMap(mutatedRoot),
     });
 });
 
@@ -338,77 +394,67 @@ test("should handle setFen", () => {
     store.setState({ ...treeE4D5(), position: [0] });
     store.getState().setFen("rnbq1bnr/ppppkppp/8/4p3/4P3/8/PPPPKPPP/RNBQ1BNR w - - 2 3");
 
+    const newRoot = {
+        ...defaultTree().root,
+        fen: "rnbq1bnr/ppppkppp/8/4p3/4P3/8/PPPPKPPP/RNBQ1BNR w - - 2 3",
+    };
     expect(getNewState()).toStrictEqual({
         ...defaultTree(),
         dirty: true,
-        root: {
-            ...defaultTree().root,
-            fen: "rnbq1bnr/ppppkppp/8/4p3/4P3/8/PPPPKPPP/RNBQ1BNR w - - 2 3",
-        },
+        root: newRoot,
+        boardStateMap: expectedMap(newRoot),
     });
 });
 
 test("should handle setScore", () => {
     store.setState({ ...treeE4D5(), position: [0] });
     store.getState().setScore({
-        value: {
-            type: "mate",
-            value: 1,
-        },
+        value: { type: "mate" as const, value: 1 },
         wdl: null,
     });
+
+    const mutatedRoot: TreeNode = {
+        ...treeE4D5().root,
+        children: [
+            {
+                ...treeE4D5().root.children[0],
+                score: {
+                    value: { type: "mate" as const, value: 1 },
+                    wdl: null,
+                },
+            },
+        ],
+    };
 
     expect(getNewState()).toStrictEqual({
         ...treeE4D5(),
         dirty: true,
         position: [0],
-        root: {
-            ...treeE4D5().root,
-            children: [
-                {
-                    ...treeE4D5().root.children[0],
-                    score: {
-                        value: {
-                            type: "mate",
-                            value: 1,
-                        },
-                        wdl: null,
-                    },
-                },
-            ],
-        },
+        root: mutatedRoot,
+        boardStateMap: expectedMap(mutatedRoot),
     });
 });
 
 test("should handle setShapes", () => {
     store.setState({ ...treeE4D5(), position: [0] });
-    store.getState().setShapes([
-        {
-            brush: "red",
-            orig: "e4",
-            dest: "d5",
-        },
-    ]);
+    store.getState().setShapes([{ brush: "red", orig: "e4", dest: "d5" }]);
+
+    const mutatedRoot: TreeNode = {
+        ...treeE4D5().root,
+        children: [
+            {
+                ...treeE4D5().root.children[0],
+                shapes: [{ brush: "red", orig: "e4", dest: "d5" }],
+            },
+        ],
+    };
 
     expect(getNewState()).toStrictEqual({
         ...treeE4D5(),
         dirty: true,
         position: [0],
-        root: {
-            ...treeE4D5().root,
-            children: [
-                {
-                    ...treeE4D5().root.children[0],
-                    shapes: [
-                        {
-                            brush: "red",
-                            orig: "e4",
-                            dest: "d5",
-                        },
-                    ],
-                },
-            ],
-        },
+        root: mutatedRoot,
+        boardStateMap: expectedMap(mutatedRoot),
     });
 });
 
@@ -459,35 +505,30 @@ test("should handle addAnalysis", () => {
         },
     ]);
 
+    const expectedRoot: TreeNode = {
+        ...treeE4D5().root,
+        children: [
+            {
+                ...treeE4D5().root.children[0],
+                score: {
+                    value: { type: "cp" as const, value: 20 },
+                    wdl: null,
+                },
+            },
+        ],
+        score: {
+            value: { type: "cp" as const, value: 10 },
+            wdl: null,
+        },
+    };
     expect(getNewState()).toStrictEqual({
         ...treeE4D5(),
         dirty: true,
         position: [0],
-        root: {
-            ...treeE4D5().root,
-            children: [
-                {
-                    ...treeE4D5().root.children[0],
-                    score: {
-                        value: {
-                            type: "cp",
-                            value: 20,
-                        },
-                        wdl: null,
-                    },
-                },
-            ],
-            score: {
-                value: {
-                    type: "cp",
-                    value: 10,
-                },
-                wdl: null,
-            },
-        },
+        root: expectedRoot,
+        boardStateMap: expectedMap(expectedRoot),
     });
 });
-
 test("should handle promoteVariation", () => {
     store.setState(treeE4D5Nf3());
     store.getState().promoteVariation([1]);
@@ -507,5 +548,16 @@ test("should handle promoteVariation", () => {
                 },
             ],
         },
+        boardStateMap: expectedMap({
+            ...treeE4D5Nf3().root,
+            children: [
+                {
+                    ...treeE4D5Nf3().root.children[1],
+                },
+                {
+                    ...treeE4D5Nf3().root.children[0],
+                },
+            ],
+        }),
     });
 });

--- a/src/utils/treeReducer.ts
+++ b/src/utils/treeReducer.ts
@@ -201,19 +201,6 @@ export function buildTranspositionMaps(
     return map;
 }
 
-export function getTreeStructureHash(node: TreeNode): string {
-    const parts: string[] = [];
-    const stack: TreeNode[] = [node];
-    while (stack.length > 0) {
-        const n = stack.pop()!;
-        parts.push(`${n.fen}|${n.san ?? ""}|${n.halfMoves}|${n.children.length}`);
-        for (let i = n.children.length - 1; i >= 0; i--) {
-            stack.push(n.children[i]);
-        }
-    }
-    return parts.join(";");
-}
-
 export interface ReportState {
     inProgress: boolean;
 }

--- a/src/utils/treeReducer.ts
+++ b/src/utils/treeReducer.ts
@@ -11,6 +11,7 @@ export interface TreeState {
     position: number[];
     dirty: boolean;
     report: ReportState;
+    boardStateMap: Record<string, { node: TreeNode; path: number[] }[]>;
 }
 
 export interface TreeNode {
@@ -104,6 +105,7 @@ export function defaultTree(fen?: string): TreeState {
         report: {
             inProgress: false,
         },
+        boardStateMap: {},
     };
 }
 
@@ -180,6 +182,25 @@ export const getNodeAtPath = (node: TreeNode, path: number[]): TreeNode => {
     return currentNode;
 };
 
+export function buildTranspositionMaps(
+    root: TreeNode,
+    startPath: number[] = [],
+): Record<string, { node: TreeNode; path: number[] }[]> {
+    const map: Record<string, { node: TreeNode; path: number[] }[]> = {};
+    const startNode = startPath.length > 0 ? getNodeAtPath(root, startPath) : root;
+
+    function traverse(node: TreeNode, path: number[]) {
+        const boardFen = getBoardState(node.fen);
+        if (!map[boardFen]) map[boardFen] = [];
+        map[boardFen].push({ node, path: [...path] });
+        for (let i = 0; i < node.children.length; i++) {
+            traverse(node.children[i], [...path, i]);
+        }
+    }
+    traverse(startNode, [...startPath]);
+    return map;
+}
+
 export function getTreeStructureHash(node: TreeNode): string {
     const parts: string[] = [];
     const stack: TreeNode[] = [node];
@@ -195,4 +216,8 @@ export function getTreeStructureHash(node: TreeNode): string {
 
 export interface ReportState {
     inProgress: boolean;
+}
+
+export function getBoardState(fen: string): string {
+    return fen.split(" ").slice(0, 4).join(" ");
 }


### PR DESCRIPTION
Original issue: https://github.com/franciscoBSalgueiro/en-croissant/issues/849

Summary
This basically builds a cache of Map<BoardState, Position[]> (this is pseudo code, not actual code) in `repertoire.ts` to store all the reached positions. 

Coverage, prepared moves,... of transpositions are all merged by union logic.

I've tested coverage computation and recomputation performance. It should be very fast (<1s). The bottleneck is database query: for each position, it needs to query white/draw/black win rate for each possible responses, which can be quite slow.

`tree.ts` and `treeReducer.ts` need to be updated to handle goToNext where you have to jump to a transpositional path.

About data structure: This is called DAG: Directed Acyclic Graph. It looks almost like a tree, but there can be multiple path from Root to any TreeNode, which represent transpositions. 