### PR TITLE
feat: implemented a custom url handler for importing games

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@tanstack/react-virtual": "^3.13.18",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-cli": "^2.4.1",
+    "@tauri-apps/plugin-deep-link": "^2.1.0",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-fs": "^2.4.5",
     "@tauri-apps/plugin-http": "^2.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@tauri-apps/plugin-cli':
         specifier: ^2.4.1
         version: 2.4.1
+      '@tauri-apps/plugin-deep-link':
+        specifier: ^2.1.0
+        version: 2.4.9
       '@tauri-apps/plugin-dialog':
         specifier: ^2.6.0
         version: 2.6.0
@@ -1609,6 +1612,9 @@ packages:
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
 
+  '@tauri-apps/api@2.11.1':
+    resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
+
   '@tauri-apps/cli-darwin-arm64@2.10.0':
     resolution: {integrity: sha512-avqHD4HRjrMamE/7R/kzJPcAJnZs0IIS+1nkDP5b+TNBn3py7N2aIo9LIpy+VQq0AkN8G5dDpZtOOBkmWt/zjA==}
     engines: {node: '>= 10'}
@@ -1687,6 +1693,9 @@ packages:
 
   '@tauri-apps/plugin-cli@2.4.1':
     resolution: {integrity: sha512-8JXofQFI5cmiGolh1PlU4hzE2YJgrgB1lyaztyBYiiMCy13luVxBXaXChYPeqMkUo46J1UadxvYdjRjj0E8zaw==}
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
 
   '@tauri-apps/plugin-dialog@2.6.0':
     resolution: {integrity: sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==}
@@ -2035,6 +2044,7 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@6.0.0':
     resolution: {integrity: sha512-Bu5/eP6td3WI654+tRq+ryW1PbgA90y5pqMKpb3U7UpNk6VjI53P/ncPUd192U9dSrepLy7DHnq1XEMDz5H++w==}
@@ -3915,6 +3925,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vfile-location@5.0.2:
@@ -5131,6 +5142,8 @@ snapshots:
 
   '@tauri-apps/api@2.10.1': {}
 
+  '@tauri-apps/api@2.11.1': {}
+
   '@tauri-apps/cli-darwin-arm64@2.10.0':
     optional: true
 
@@ -5181,6 +5194,10 @@ snapshots:
   '@tauri-apps/plugin-cli@2.4.1':
     dependencies:
       '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-dialog@2.6.0':
     dependencies:

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -66,6 +66,8 @@ tauri-plugin-process = "2.3.1"
 tauri-plugin-log = "2.8.0"
 tauri-plugin-window-state = "2.4.1"
 tauri-plugin-opener = "2"
+tauri-plugin-deep-link = "2.0.0"
+tauri-plugin-single-instance = { version = "2.0.0", features = ["deep-link"] }
 memmap2 = "0.9"
 rkyv = { version = "0.8", features = ["bytecheck"] }
 polyglot-book-rs = "0.1.0"

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -23,6 +23,7 @@
             ]
         },
         "dialog:default",
+        "deep-link:default",
         "os:default",
         "cli:default",
         "updater:default",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -199,6 +199,15 @@ fn main() {
     ];
 
     tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            let _ = app
+                .get_webview_window("main")
+                .map(|w| {
+                    let _ = w.show();
+                    let _ = w.set_focus();
+                });
+        }))
+        .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -49,6 +49,13 @@
   "mainBinaryName": "en-croissant",
   "identifier": "org.encroissant.app",
   "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": [
+          "encroissant"
+        ]
+      }
+    },
     "cli": {
       "args": [
         {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import {
   Textarea,
   TextInput,
 } from "@mantine/core";
-import { Notifications } from "@mantine/notifications";
+import { Notifications, notifications } from "@mantine/notifications";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { getMatches } from "@tauri-apps/plugin-cli";
 import { listen } from "@tauri-apps/api/event";
@@ -17,6 +17,8 @@ import { getDefaultStore, useAtom, useAtomValue, useSetAtom } from "jotai";
 import { ContextMenuProvider } from "mantine-contextmenu";
 import posthog from "posthog-js";
 import { useEffect, useRef } from "react";
+import { getCurrent, onOpenUrl } from "@tauri-apps/plugin-deep-link";
+import type { Tab } from "@/utils/tabs";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import {
@@ -51,6 +53,10 @@ import "@/styles/global.css";
 
 import { commands } from "./bindings";
 import { openFile } from "./utils/files";
+import { getGameFromUrl } from "./utils/import";
+import { createTab } from "./utils/tabs";
+import { parsePGN } from "./utils/chess";
+import { getGameName } from "./utils/treeReducer";
 
 const colorSchemeManager = localStorageColorSchemeManager({
   key: "mantine-color-scheme",
@@ -143,6 +149,80 @@ const preloadReferenceDb = async (store: ReturnType<typeof getDefaultStore>) => 
   }
 };
 
+const handleDeepLink = async (
+  urlStr: string,
+  setTabs: React.Dispatch<React.SetStateAction<Tab[]>>,
+  setActiveTab: React.Dispatch<React.SetStateAction<string | null>>,
+) => {
+  let notificationShown = false;
+  try {
+    const url = new URL(urlStr);
+    if (url.protocol !== "encroissant:") return;
+
+    if (url.host === "import") {
+      const gameUrl = url.searchParams.get("url");
+      if (!gameUrl) {
+        throw new Error("No URL parameter provided in encroissant://import");
+      }
+
+      notifications.show({
+        title: "Importing game",
+        message: `Loading game from ${gameUrl}...`,
+        loading: true,
+        autoClose: false,
+        id: "importing-game-link",
+      });
+      notificationShown = true;
+
+      const pgn = await getGameFromUrl(gameUrl);
+      if (!pgn) {
+        throw new Error("No PGN data found");
+      }
+
+      const tree = await parsePGN(pgn);
+      const name = getGameName(tree.headers);
+
+      await createTab({
+        tab: {
+          name,
+          type: "analysis",
+        },
+        setTabs,
+        setActiveTab,
+        pgn,
+      });
+
+      notifications.update({
+        id: "importing-game-link",
+        title: "Import successful",
+        message: "Game imported successfully",
+        color: "green",
+        autoClose: 3000,
+        loading: false,
+      });
+    }
+  } catch (e) {
+    error(`Failed to handle deep link URL: ${urlStr} - ${e}`);
+    const errorMessage = e instanceof Error ? e.message : String(e);
+    if (notificationShown) {
+      notifications.update({
+        id: "importing-game-link",
+        title: "Import failed",
+        message: errorMessage,
+        color: "red",
+        autoClose: 5000,
+        loading: false,
+      });
+    } else {
+      notifications.show({
+        title: "Import error",
+        message: errorMessage,
+        color: "red",
+      });
+    }
+  }
+};
+
 function useAppStartup() {
   const initialized = useRef(false);
   const [, setTabs] = useAtom(tabsAtom);
@@ -190,7 +270,28 @@ function useAppStartup() {
 
       await preloadReferenceDb(store);
 
-      return detach;
+      let unlistenDeepLink: (() => void) | undefined;
+      try {
+        const initialUrls = await getCurrent();
+        if (initialUrls && initialUrls.length > 0) {
+          for (const url of initialUrls) {
+            void handleDeepLink(url, setTabs, setActiveTab);
+          }
+        }
+
+        unlistenDeepLink = await onOpenUrl((urls) => {
+          for (const url of urls) {
+            void handleDeepLink(url, setTabs, setActiveTab);
+          }
+        });
+      } catch (e) {
+        warn(`Failed to setup deep links: ${e}`);
+      }
+
+      return () => {
+        if (detach) detach();
+        if (unlistenDeepLink) unlistenDeepLink();
+      };
     };
 
     let detachFn: (() => void) | undefined;

--- a/src/components/tabs/ImportModal.tsx
+++ b/src/components/tabs/ImportModal.tsx
@@ -23,10 +23,9 @@ import { match } from "ts-pattern";
 import { commands } from "@/bindings";
 import { addRecentFileAtom, currentTabAtom } from "@/state/atoms";
 import { parsePGN } from "@/utils/chess";
-import { getChesscomGame } from "@/utils/chess.com/api";
 import { chessopsError } from "@/utils/chessops";
 import { createFile, openFile } from "@/utils/files";
-import { getLichessGame } from "@/utils/lichess/api";
+import { getGameFromUrl } from "@/utils/import";
 import { isInTempDir, type Tab } from "@/utils/tabs";
 import { defaultTree, getGameName } from "@/utils/treeReducer";
 import { unwrap } from "@/utils/unwrap";
@@ -141,23 +140,11 @@ export default function ImportModal({
         return;
       }
       let pgn = "";
-      if (link.includes("chess.com")) {
-        const res = await getChesscomGame(link);
-        if (res === null) {
-          setLoading(false);
-          return;
-        }
-        pgn = res;
-      } else if (link.includes("lichess")) {
-        const excludedPathParts = ["game", "export", "white", "black"];
-        const gameId = new URL(link).pathname
-          .split("/")
-          .find((x) => x && !excludedPathParts.includes(x));
-        if (!gameId) {
-          setLoading(false);
-          return;
-        }
-        pgn = await getLichessGame(gameId);
+      try {
+        pgn = await getGameFromUrl(link);
+      } catch (e) {
+        setLoading(false);
+        return;
       }
 
       const tree = await parsePGN(pgn);

--- a/src/utils/import.ts
+++ b/src/utils/import.ts
@@ -1,0 +1,23 @@
+import { getChesscomGame } from "./chess.com/api";
+import { getLichessGame } from "./lichess/api";
+
+export async function getGameFromUrl(url: string): Promise<string> {
+    if (url.includes("chess.com")) {
+        const res = await getChesscomGame(url);
+        if (res === null) {
+            throw new Error("Failed to load Chess.com game");
+        }
+        return res;
+    } else if (url.includes("lichess.org")) {
+        const excludedPathParts = ["game", "export", "white", "black"];
+        const gameId = new URL(url).pathname
+            .split("/")
+            .find((x) => x && !excludedPathParts.includes(x));
+        if (!gameId) {
+            throw new Error("Failed to load lichess game: invalid URL");
+        }
+        return await getLichessGame(gameId);
+    } else {
+        throw new Error(`Failed to load game from unsupported URL: ${url}`);
+    }
+}


### PR DESCRIPTION
I implemented a handler that responds to `encroissant://import?url=...` urls by trying to import the specified game (i.e., downloading it from Chess.com or lichess).

This allows to launch En Croissant and import a spcific game from other applications. 

For example, i developed [this](https://github.com/deluf/open-in-en-croissant) chromium/firefox extension which adds a button to Chess.com that opens the current game in the En Croissant desktop app:

<img width="1280" height="800" alt="demo" src="https://github.com/user-attachments/assets/4f83790b-2f18-4cf8-918f-cbb567071527" />

This can be extended in order to implement other actions, such as importing a specific game and automatically starting the engine report (mimicking the chess.com game analysis feature).