### PR TITLE
make the table sortable

### DIFF
--- a/src/components/panels/database/GamesTable.tsx
+++ b/src/components/panels/database/GamesTable.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@mantine/core";
 import { useNavigate } from "@tanstack/react-router";
 import { useAtom, useSetAtom } from "jotai";
-import { DataTable } from "mantine-datatable";
-import { memo, useEffect, useState } from "react";
+import { DataTable, type DataTableSortStatus } from "mantine-datatable";
+import { memo, useEffect, useMemo, useState } from "react";
 import type { NormalizedGame } from "@/bindings";
 import { activeTabAtom, tabsAtom } from "@/state/atoms";
 import { createTab } from "@/utils/tabs";
@@ -19,11 +19,45 @@ function GamesTable({
   const [, setTabs] = useAtom(tabsAtom);
   const setActiveTab = useSetAtom(activeTabAtom);
   const [page, setPage] = useState(1);
-  const filteredGames = games.slice((page - 1) * 20, page * 20);
+  const [sortStatus, setSortStatus] = useState<DataTableSortStatus<NormalizedGame>>({
+    columnAccessor: "date",
+    direction: "desc",
+  });
+
+  // Sorts the full result set client-side according to the current sort status
+  // (column + direction), before pagination slices out the visible page.
+  // The column accessor is a key of NormalizedGame, so the values being
+  // compared are strings (player names, date), numbers (ply count) or
+  // null/undefined (optional fields like date and ply_count). Strings are
+  // compared with localeCompare, numbers with </>, and missing values are
+  // always pushed to the end regardless of direction. The comparison result
+  // is negated for descending order. Memoized so the sort only reruns when
+  // the games or the sort status change, not on every render (e.g. paging).
+  const sortedGames = useMemo(() => {
+    const key = sortStatus.columnAccessor as keyof NormalizedGame;
+    return [...games].sort((a, b) => {
+      const av = a[key];
+      const bv = b[key];
+      // missing values always sort last
+      if (av == null && bv == null) return 0;
+      if (av == null) return 1;
+      if (bv == null) return -1;
+      const cmp =
+        typeof av === "string" && typeof bv === "string"
+          ? av.localeCompare(bv)
+          : av < bv
+            ? -1
+            : av > bv
+              ? 1
+              : 0;
+      return sortStatus.direction === "desc" ? -cmp : cmp;
+    });
+  }, [games, sortStatus]);
+  const filteredGames = sortedGames.slice((page - 1) * 20, page * 20);
 
   useEffect(() => {
     setPage(1);
-  }, [games]);
+  }, [games, sortStatus]);
 
   const navigate = useNavigate();
   return (
@@ -36,6 +70,8 @@ function GamesTable({
       recordsPerPage={20}
       page={page}
       onPageChange={setPage}
+      sortStatus={sortStatus}
+      onSortStatusChange={setSortStatus}
       onRowClick={(e) => {
         const game = e.record;
         createTab({
@@ -60,6 +96,7 @@ function GamesTable({
       columns={[
         {
           accessor: "white",
+          sortable: true,
           render: ({ white, white_elo }) => (
             <div>
               <Text size="sm" fw={500}>
@@ -73,6 +110,7 @@ function GamesTable({
         },
         {
           accessor: "black",
+          sortable: true,
           render: ({ black, black_elo }) => (
             <div>
               <Text size="sm" fw={500}>
@@ -84,9 +122,9 @@ function GamesTable({
             </div>
           ),
         },
-        { accessor: "date" },
-        { accessor: "result" },
-        { accessor: "ply_count" },
+        { accessor: "date", sortable: true },
+        { accessor: "result", sortable: true },
+        { accessor: "ply_count", sortable: true },
       ]}
       noRecordsText="No games found"
     />


### PR DESCRIPTION
This commit adds the ability to sort the games table (GamesTable). This is super handy as one can easily sort by date or username or whatever. 

<img width="609" height="160" alt="image" src="https://github.com/user-attachments/assets/63baf689-ad67-4e85-9fb6-03ccd0eb5e66" />
