### PR TITLE
Preserve game UTC time on edit

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1109,6 +1109,33 @@ pub async fn get_games(
     })
 }
 
+fn get_latest_game_timestamp_in_db(db: &mut SqliteConnection) -> Result<Option<i64>, Error> {
+    let timestamps = games::table
+        .select((games::date, games::time))
+        .filter(games::date.is_not_null())
+        .filter(games::time.is_not_null())
+        .load::<(Option<String>, Option<String>)>(db)?;
+
+    Ok(timestamps
+        .into_iter()
+        .filter_map(|(date, time)| {
+            let date = NaiveDate::parse_from_str(date?.as_str(), "%Y.%m.%d").ok()?;
+            let time = NaiveTime::parse_from_str(time?.as_str(), "%H:%M:%S").ok()?;
+            Some(date.and_time(time).and_utc().timestamp_millis())
+        })
+        .max())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn get_latest_game_timestamp(
+    file: PathBuf,
+    state: tauri::State<'_, AppState>,
+) -> Result<Option<f64>, Error> {
+    let db = &mut get_db_or_create(&state, file.to_str().unwrap(), ConnectionOptions::default())?;
+    Ok(get_latest_game_timestamp_in_db(db)?.map(|timestamp| timestamp as f64))
+}
+
 fn normalize_games(games: Vec<(Game, Player, Player, Event, Site)>) -> Vec<NormalizedGame> {
     games
         .into_iter()
@@ -1619,6 +1646,7 @@ struct PgnGame {
     event: Option<String>,
     site: Option<String>,
     date: Option<String>,
+    time: Option<String>,
     round: Option<String>,
     white: Option<String>,
     black: Option<String>,
@@ -1641,6 +1669,11 @@ impl PgnGame {
         )?;
         writeln!(writer, "[Site \"{}\"]", self.site.as_deref().unwrap_or(""))?;
         writeln!(writer, "[Date \"{}\"]", self.date.as_deref().unwrap_or(""))?;
+        if let Some(time) = self.time.as_deref() {
+            if !time.is_empty() {
+                writeln!(writer, "[UTCTime \"{}\"]", time)?;
+            }
+        }
         writeln!(
             writer,
             "[Round \"{}\"]",
@@ -1735,6 +1768,7 @@ pub async fn export_to_pgn(
                 event: event.name,
                 site: site.name,
                 date: game.date,
+                time: game.time,
                 round: game.round,
                 white: white.name,
                 black: black.name,
@@ -1798,6 +1832,13 @@ pub async fn write_db_game(
         .flatten()
         .flatten();
     let temp_game = parsed.next().ok_or(Error::NoMovesFound)?;
+    let existing_time = games::table
+        .filter(games::id.eq(game_id))
+        .select(games::time)
+        .first::<Option<String>>(db)
+        .optional()?
+        .flatten();
+    let game_time = temp_game.time.clone().or(existing_time);
 
     let white_id = if let Some(name) = temp_game.white_name.as_deref() {
         create_player(db, name)?.id
@@ -1831,7 +1872,7 @@ pub async fn write_db_game(
             games::event_id.eq(event_id),
             games::site_id.eq(site_id),
             games::date.eq(temp_game.date),
-            games::time.eq(temp_game.time),
+            games::time.eq(game_time),
             games::round.eq(temp_game.round),
             games::white_id.eq(white_id),
             games::white_elo.eq(temp_game.white_elo),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -62,8 +62,8 @@ use crate::sound::get_sound_server_port;
 use crate::{
     chess::get_best_moves,
     db::{
-        delete_duplicated_games, edit_db_info, get_db_info, get_games, get_players, merge_players,
-        write_db_game,
+        delete_duplicated_games, edit_db_info, get_db_info, get_games, get_latest_game_timestamp,
+        get_players, merge_players, write_db_game,
     },
     fs::{download_file, file_exists, get_file_metadata},
     opening::{
@@ -152,6 +152,7 @@ fn main() {
             get_tournaments,
             get_db_info,
             get_games,
+            get_latest_game_timestamp,
             search_position,
             get_players,
             get_puzzle_db_info,

--- a/src/bindings/generated.ts
+++ b/src/bindings/generated.ts
@@ -120,6 +120,14 @@ async getPlayersGameInfo(file: string, id: number) : Promise<Result<PlayerGameIn
     else return { status: "error", error: e  as any };
 }
 },
+async getLatestGameTimestamp(file: string) : Promise<Result<number | null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_latest_game_timestamp", { file }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async getEngineConfig(path: string) : Promise<Result<EngineConfig, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_engine_config", { path }) };

--- a/src/components/home/AccountCard.tsx
+++ b/src/components/home/AccountCard.tsx
@@ -29,7 +29,7 @@ import type { DatabaseInfo } from "@/bindings";
 import { commands, events } from "@/bindings";
 import { databaseConversionStateAtom, storedDatabasesDirAtom } from "@/state/atoms";
 import { downloadChessCom } from "@/utils/chess.com/api";
-import { getDatabases, query_games } from "@/utils/db";
+import { getDatabases } from "@/utils/db";
 import { capitalize } from "@/utils/format";
 import { downloadLichess } from "@/utils/lichess/api";
 import { unwrap } from "@/utils/unwrap";
@@ -158,22 +158,7 @@ export function AccountCard({
     effectiveTotal === 0 ? "0.00" : ((downloadedGames / effectiveTotal) * 100).toFixed(2);
 
   async function getLastGameDate({ database }: { database: DatabaseInfo }) {
-    const games = await query_games(database.file, {
-      options: {
-        page: 1,
-        pageSize: 1,
-        sort: "date",
-        direction: "desc",
-        skipCount: false,
-      },
-    });
-    if (games.count! > 0 && games.data[0].date && games.data[0].time) {
-      const [year, month, day] = games.data[0].date.split(".").map(Number);
-      const [hour, minute, second] = games.data[0].time.split(":").map(Number);
-      const d = Date.UTC(year, month - 1, day, hour, minute, second);
-      return d;
-    }
-    return null;
+    return unwrap(await commands.getLatestGameTimestamp(database.file));
   }
 
   return (

--- a/src/utils/chess.ts
+++ b/src/utils/chess.ts
@@ -178,6 +178,9 @@ export function headersToPGN(game: GameHeaders): string {
 [Black "${game.black || "?"}"]
 [Result "${game.result}"]
 `;
+    if (game.time) {
+        headers += `[UTCTime "${game.time}"]\n`;
+    }
     if (game.white_elo !== undefined && game.white_elo !== null) {
         headers += `[WhiteElo "${game.white_elo === 0 ? "-" : game.white_elo}"]\n`;
     }


### PR DESCRIPTION
Fix issue #824: `UTCTime` will not be wiped when editing a game.

  1. Preserve the existing database `UTCTime` after editting.
  2. Preserve `UTCTime` when serializing game headers to PGN.
  3. Change the account download cutoff logic to use the latest valid `Date + UTCTime` from the database instead of the first game returned by
  the paginated query.

  This also fixes the duplicate Chess.com download behavior described in #815, because that issue is caused by the edited latest game losing
  `UTCTime`.
