### PR TITLE
Turn off autofocus for annotation box 

### DIFF
--- a/src/components/panels/annotation/AnnotationEditor.tsx
+++ b/src/components/panels/annotation/AnnotationEditor.tsx
@@ -23,7 +23,7 @@ function AnnotationEditor() {
   const spellCheck = useAtomValue(spellCheckAtom);
   const editor = useEditor(
     {
-      autofocus: "end",
+      autofocus: false,
       extensions: [
         StarterKit.configure({
           link: {


### PR DESCRIPTION
When a user is annotating their game, it is often convenient to use the arrow keys to scroll through the game and use the buttons to add annotations like `!!` or `??`. When the annotation text field is focused, this is not possible.

This MR simply sets autofocus to false. 

Thanks!