### PR TITLE
Add markdown source editor for annotations

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
+allowBuilds:
+  '@parcel/watcher': true
+  '@swc/core': true
+  core-js: true
+  esbuild: true
+  protobufjs: true
 onlyBuiltDependencies:
   - "@parcel/watcher"
   - "@swc/core"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,4 +4,3 @@ onlyBuiltDependencies:
   - core-js
   - esbuild
   - protobufjs
-  

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,12 +1,7 @@
-allowBuilds:
-  '@parcel/watcher': true
-  '@swc/core': true
-  core-js: true
-  esbuild: true
-  protobufjs: true
 onlyBuiltDependencies:
   - "@parcel/watcher"
   - "@swc/core"
   - core-js
   - esbuild
   - protobufjs
+  

--- a/src/components/panels/annotation/AnnotationEditor.tsx
+++ b/src/components/panels/annotation/AnnotationEditor.tsx
@@ -1,9 +1,10 @@
+import { SegmentedControl, Stack, Textarea } from "@mantine/core";
 import { RichTextEditor } from "@mantine/tiptap";
 import Placeholder from "@tiptap/extension-placeholder";
 import { Markdown } from "@tiptap/markdown";
 import { useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import { useAtomValue } from "jotai";
+import { atom, useAtom, useAtomValue } from "jotai";
 import { useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
@@ -11,16 +12,22 @@ import { TreeStateContext } from "@/components/common/TreeStateContext";
 import { spellCheckAtom } from "@/state/atoms";
 import { getNodeAtPath } from "@/utils/treeReducer";
 
-function AnnotationEditor() {
+type EditorMode = "rich" | "source";
+
+const annotationEditorModeAtom = atom<EditorMode>("rich");
+
+function RichAnnotationEditor({
+  comment,
+  spellCheck,
+  setComment,
+  position,
+}: {
+  comment: string;
+  spellCheck: boolean;
+  setComment: (value: string) => void;
+  position: number[];
+}) {
   const { t } = useTranslation();
-
-  const store = useContext(TreeStateContext)!;
-  const root = useStore(store, (s) => s.root);
-  const position = useStore(store, (s) => s.position);
-  const setComment = useStore(store, (s) => s.setComment);
-
-  const currentNode = getNodeAtPath(root, position);
-  const spellCheck = useAtomValue(spellCheckAtom);
   const editor = useEditor(
     {
       autofocus: "end",
@@ -34,7 +41,7 @@ function AnnotationEditor() {
         Markdown,
         Placeholder.configure({ placeholder: t("Board.Annotate.WriteHere") }),
       ],
-      content: currentNode.comment || null,
+      content: comment || null,
       contentType: "markdown",
       onUpdate: ({ editor }) => {
         setComment(editor.getMarkdown());
@@ -95,6 +102,75 @@ function AnnotationEditor() {
 
       <RichTextEditor.Content />
     </RichTextEditor>
+  );
+}
+
+function SourceAnnotationEditor({
+  comment,
+  spellCheck,
+  setComment,
+}: {
+  comment: string;
+  spellCheck: boolean;
+  setComment: (value: string) => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <Textarea
+      value={comment}
+      onChange={(event) => setComment(event.currentTarget.value)}
+      autosize
+      minRows={12}
+      spellCheck={spellCheck}
+      placeholder={t("Board.Annotate.WriteHere")}
+      styles={{
+        input: {
+          fontFamily: "monospace",
+        },
+      }}
+    />
+  );
+}
+
+function AnnotationEditor() {
+  const [editorMode, setEditorMode] = useAtom(annotationEditorModeAtom);
+
+  // these variables are used across both rich and source editors
+  const store = useContext(TreeStateContext)!;
+  const root = useStore(store, (s) => s.root);
+  const position = useStore(store, (s) => s.position);
+  const setComment = useStore(store, (s) => s.setComment);
+
+  const currentNode = getNodeAtPath(root, position);
+  const spellCheck = useAtomValue(spellCheckAtom);
+
+  return (
+    <Stack gap="xs">
+      <SegmentedControl
+        size="xs"
+        value={editorMode}
+        onChange={(mode) => setEditorMode(mode as EditorMode)}
+        data={[
+          { value: "rich", label: "Rich text" },
+          { value: "source", label: "Source" },
+        ]}
+      />
+      {editorMode === "source" ? (
+        <SourceAnnotationEditor
+          comment={currentNode.comment}
+          spellCheck={spellCheck}
+          setComment={setComment}
+        />
+      ) : (
+        <RichAnnotationEditor
+          comment={currentNode.comment}
+          spellCheck={spellCheck}
+          setComment={setComment}
+          position={position}
+        />
+      )}
+    </Stack>
   );
 }
 


### PR DESCRIPTION
I was using the regular rich text editor when I tried to comment on a move with bullet points. The built-in rich text editor has a quirk where there will always be a newline after a bulleted list, which created this awkward space in the move view. I also tried copying and pasting things to get it to work better, but copying and pasting was also awkward.

I used GitHub Copilot to generate a quick fix and I went through the code to make sure it didn't do something dumb, and after verifying that there weren't any weird additions, I locally ran the build and continued my analysis as a way of ensuring quality assurance in case there were any quirks. Everything works as planned and it seems somewhat convenient. (well, for me at least)

The new addition can be seen in the toggle between rich text and source editing.
<img width="1666" height="938" alt="image" src="https://github.com/user-attachments/assets/d78df40f-e1f9-4a21-bed2-d394e46296b6" />

## Changes

More React components were imported from the same component library that was used for the textbox. Some code was also moved around because source editing and rich text editing both still rely on the same functions that write and retrieve data. Some variable names were also changed appropriately to differentiate rich and source editing, namely `AnnotationEditor` to `RichAnnotationEditor`, repurposing the original variable name to contain both the rich editor and the source editor.

### Rationale

So at first I would've preferred a source button on the same layout as the rest of the rich text editing. In fact, it's built into the library. The only thing is that it sucks. The rich text editor processes text in HTML, not Markdown, so the source would be in the wrong format. The agent tried to edit it so that it would serialize it to and from Markdown. The only issue is, it's still fundamentally a rich text editor so if someone were to scroll through another annotation it would put rich text in the source, which is then removed when switching back. It was just a whole can of worms and the current implementation seems to be the most reasonable because of it.