### PR TITLE
Fix en-croissant app name on Linux systems

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,7 +45,7 @@
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420"
   },
-  "productName": "en-croissant",
+  "productName": "En Croissant",
   "mainBinaryName": "en-croissant",
   "identifier": "org.encroissant.app",
   "plugins": {


### PR DESCRIPTION
If you install the app through the RPM or DEB files on Linux, the app name will appear as `en-croissant` instead of `En Croissant` as it probably should be. Here is a screenshot from Fedora KDE:
<img width="1920" height="1080" alt="Screenshot_20260815_165921" src="https://github.com/user-attachments/assets/1a41348f-1cdc-427b-b9bb-4ed0a23db746" />
I think this change should fix it but I can't test it so let me know if I've made a mistake.