### PR TITLE
fix: hide variation arrows while practicing

### DIFF
--- a/src/components/boards/Board.tsx
+++ b/src/components/boards/Board.tsx
@@ -291,7 +291,7 @@ function Board({
   }
 
   // Variation arrows: show all children moves when there are alternatives
-  if (showVariationArrows && currentNode.children.length > 1) {
+  if (showVariationArrows && !practicing && currentNode.children.length > 1) {
     for (const child of currentNode.children) {
       if (child.move) {
         const m = child.move as NormalMove;


### PR DESCRIPTION
## Summary
Fixes #871. When the "Variation arrows" setting is enabled, alternative moves at the current node are drawn on the board — but this also happened during an active practice session, revealing the correct move early and defeating the purpose of practice mode.

## Root cause
`Board.tsx` computes variation arrows purely from `currentNode.children`, independent of practice-mode state, so they leak through regardless of context. Best-move engine arrows don't have this problem only because the analysis panel unmounts on the practice tab — but variation arrows aren't gated by that at all.

## Fix
`Board.tsx` already receives a `practicing` prop that's consulted elsewhere in the same component (move gating at line ~180, `practiceLock` at line ~325). This adds the same check to the variation-arrows condition:

```diff
- if (showVariationArrows && currentNode.children.length > 1) {
+ if (showVariationArrows && !practicing && currentNode.children.length > 1) {
```

Minimal, one line, no new state or prop threading needed.

## Test plan
- [x] `pnpm lint` (`tsgo --noEmit && oxlint`): 0 errors (pre-existing unrelated warnings only)
- [x] `git diff` confirms only the intended one-line change