### PR TITLE
Add variation picker popup for move navigation

### DIFF
--- a/src/components/common/GameNotation.tsx
+++ b/src/components/common/GameNotation.tsx
@@ -10,8 +10,9 @@ import {
   Table,
   Text,
   Tooltip,
+  UnstyledButton,
 } from "@mantine/core";
-import { useColorScheme } from "@mantine/hooks";
+import { useClickOutside, useColorScheme } from "@mantine/hooks";
 import {
   IconArrowRight,
   IconArrowsSplit,
@@ -87,6 +88,7 @@ function GameNotation({ topBar, controls }: { topBar?: boolean; controls?: React
 
   return (
     <Paper withBorder flex={1} style={{ position: "relative", overflow: "hidden" }}>
+      <VariationChoiceOverlay />
       <Group h="100%" wrap="nowrap" align="stretch" gap={0}>
         {controls && (
           <>
@@ -142,6 +144,66 @@ function GameNotation({ topBar, controls }: { topBar?: boolean; controls?: React
         </Stack>
       </Group>
     </Paper>
+  );
+}
+
+function VariationChoiceOverlay() {
+  const store = useContext(TreeStateContext)!;
+  const { t } = useTranslation();
+  const opened = useStore(store, (s) => s.variationMenuOpened);
+  const node = useStore(store, (s) => s.currentNode());
+  const position = useStore(store, (s) => s.position);
+  const highlightedIndex = useStore(store, (s) => s.highlightedVariationIndex);
+  const goToMove = useStore(store, (s) => s.goToMove);
+  const closeVariationMenu = useStore(store, (s) => s.closeVariationMenu);
+  const cardRef = useClickOutside(() => closeVariationMenu());
+
+  if (!opened) {
+    return null;
+  }
+
+  return (
+    <>
+      <Overlay backgroundOpacity={0.35} blur={1} zIndex={20} onClick={closeVariationMenu} />
+      <Paper
+        ref={cardRef}
+        withBorder
+        shadow="xl"
+        p="md"
+        radius="md"
+        w={280}
+        style={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          zIndex: 21,
+        }}
+      >
+        <Text fw={600} size="sm" mb="sm">
+          {t("Menu.ChooseNextMove")}
+        </Text>
+        <Stack gap={4}>
+          {node.children.map((child, i) => (
+            <UnstyledButton
+              key={`${child.san}-${i}`}
+              onClick={() => goToMove([...position, i])}
+              px="sm"
+              py={8}
+              style={{
+                borderRadius: 6,
+                backgroundColor:
+                  i === highlightedIndex ? "var(--mantine-color-blue-light)" : undefined,
+              }}
+            >
+              <Text size="sm" fw={i === highlightedIndex ? 600 : 400}>
+                {child.san}
+              </Text>
+            </UnstyledButton>
+          ))}
+        </Stack>
+      </Paper>
+    </>
   );
 }
 

--- a/src/components/common/MoveControls.tsx
+++ b/src/components/common/MoveControls.tsx
@@ -6,7 +6,7 @@ import {
   IconChevronsRight,
 } from "@tabler/icons-react";
 import { useAtomValue } from "jotai";
-import { memo, useContext } from "react";
+import { memo, useCallback, useContext } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useStore } from "zustand";
 import { keyMapAtom } from "@/state/keybinds";
@@ -25,29 +25,74 @@ function MoveControls({ readOnly }: { readOnly?: boolean }) {
   const previousBranch = useStore(store, (s) => s.previousBranch);
   const nextBranching = useStore(store, (s) => s.nextBranching);
   const previousBranching = useStore(store, (s) => s.previousBranching);
+  const currentNode = useStore(store, (s) => s.currentNode());
+  const practicePath = useStore(store, (s) => s.practicePath);
+  const variationMenuOpened = useStore(store, (s) => s.variationMenuOpened);
+  const openVariationMenu = useStore(store, (s) => s.openVariationMenu);
+  const closeVariationMenu = useStore(store, (s) => s.closeVariationMenu);
+  const moveVariationHighlight = useStore(store, (s) => s.moveVariationHighlight);
+  const confirmVariationChoice = useStore(store, (s) => s.confirmVariationChoice);
+
+  const hasVariations = currentNode.children.length > 1 && !practicePath;
+
+  const handleNext = useCallback(() => {
+    if (variationMenuOpened) {
+      moveVariationHighlight(1);
+    } else if (hasVariations) {
+      openVariationMenu();
+    } else {
+      next();
+    }
+  }, [variationMenuOpened, hasVariations, moveVariationHighlight, openVariationMenu, next]);
+
+  const handlePrevious = useCallback(() => {
+    if (variationMenuOpened) {
+      moveVariationHighlight(-1);
+    } else {
+      previous();
+    }
+  }, [variationMenuOpened, moveVariationHighlight, previous]);
+
+  const handleBranchEnd = useCallback(() => {
+    if (variationMenuOpened) {
+      moveVariationHighlight(1);
+    } else {
+      endBranch();
+    }
+  }, [variationMenuOpened, moveVariationHighlight, endBranch]);
+
+  const handleBranchStart = useCallback(() => {
+    if (variationMenuOpened) {
+      moveVariationHighlight(-1);
+    } else {
+      startBranch();
+    }
+  }, [variationMenuOpened, moveVariationHighlight, startBranch]);
 
   const keyMap = useAtomValue(keyMapAtom);
-  useHotkeys(keyMap.PREVIOUS_MOVE.keys, previous);
-  useHotkeys(keyMap.NEXT_MOVE.keys, next);
+  useHotkeys(keyMap.PREVIOUS_MOVE.keys, handlePrevious);
+  useHotkeys(keyMap.NEXT_MOVE.keys, handleNext);
   useHotkeys(keyMap.GO_TO_START.keys, start);
   useHotkeys(keyMap.GO_TO_END.keys, end);
   useHotkeys(keyMap.DELETE_MOVE.keys, readOnly ? () => {} : () => deleteMove());
-  useHotkeys(keyMap.GO_TO_BRANCH_START.keys, startBranch);
-  useHotkeys(keyMap.GO_TO_BRANCH_END.keys, endBranch);
+  useHotkeys(keyMap.GO_TO_BRANCH_START.keys, handleBranchStart);
+  useHotkeys(keyMap.GO_TO_BRANCH_END.keys, handleBranchEnd);
   useHotkeys(keyMap.NEXT_BRANCH.keys, nextBranch);
   useHotkeys(keyMap.PREVIOUS_BRANCH.keys, previousBranch);
   useHotkeys(keyMap.NEXT_BRANCHING.keys, nextBranching);
   useHotkeys(keyMap.PREVIOUS_BRANCHING.keys, previousBranching);
+  useHotkeys("enter", () => variationMenuOpened && confirmVariationChoice());
+  useHotkeys("escape", () => variationMenuOpened && closeVariationMenu());
 
   return (
     <Group grow gap="xs">
       <ActionIcon variant="default" size="lg" onClick={start}>
         <IconChevronsLeft />
       </ActionIcon>
-      <ActionIcon variant="default" size="lg" onClick={previous}>
+      <ActionIcon variant="default" size="lg" onClick={handlePrevious}>
         <IconChevronLeft />
       </ActionIcon>
-      <ActionIcon variant="default" size="lg" onClick={next}>
+      <ActionIcon variant="default" size="lg" onClick={handleNext}>
         <IconChevronRight />
       </ActionIcon>
       <ActionIcon variant="default" size="lg" onClick={end}>

--- a/src/state/store/tree.ts
+++ b/src/state/store/tree.ts
@@ -85,6 +85,13 @@ export interface TreeStoreState extends TreeState {
     practicePath: number[] | null;
     setPracticePath: (path: number[] | null) => void;
 
+    variationMenuOpened: boolean;
+    highlightedVariationIndex: number;
+    openVariationMenu: () => void;
+    closeVariationMenu: () => void;
+    moveVariationHighlight: (delta: number) => void;
+    confirmVariationChoice: () => void;
+
     setState: (state: TreeState) => void;
     reset: () => void;
     save: () => void;
@@ -101,6 +108,42 @@ export const createTreeStore = (id?: string, initialTree?: TreeState) => {
 
         practicePath: null,
         setPracticePath: (path) => set({ practicePath: path }),
+
+        variationMenuOpened: false,
+        highlightedVariationIndex: 0,
+
+        openVariationMenu: () =>
+            set((state) => {
+                const node = getNodeAtPath(state.root, state.position);
+                if (node.children.length <= 1) return state;
+                return { ...state, variationMenuOpened: true, highlightedVariationIndex: 0 };
+            }),
+
+        closeVariationMenu: () => set({ variationMenuOpened: false }),
+
+        moveVariationHighlight: (delta) =>
+            set((state) => {
+                if (!state.variationMenuOpened) return state;
+                const node = getNodeAtPath(state.root, state.position);
+                const len = node.children.length;
+                if (len === 0) return state;
+                const nextIndex = ((state.highlightedVariationIndex + delta) % len + len) % len;
+                return { ...state, highlightedVariationIndex: nextIndex };
+            }),
+
+        confirmVariationChoice: () =>
+            set((state) => {
+                if (!state.variationMenuOpened) return state;
+                const node = getNodeAtPath(state.root, state.position);
+                const child = node.children[state.highlightedVariationIndex];
+                if (!child?.move) return { ...state, variationMenuOpened: false };
+                if (child.san) playSound(child.san.includes("x"), child.san.includes("+"));
+                return {
+                    ...state,
+                    position: [...state.position, state.highlightedVariationIndex],
+                    variationMenuOpened: false,
+                };
+            }),
 
         setState: (state) => {
             set(() => state);
@@ -258,6 +301,7 @@ export const createTreeStore = (id?: string, initialTree?: TreeState) => {
             set((state) => ({
                 ...state,
                 position: move,
+                variationMenuOpened: false,
             })),
         goToBranchStart: () => {
             set(

--- a/src/translation/en-US.json
+++ b/src/translation/en-US.json
@@ -411,6 +411,7 @@
     "Menu.Application.About": "About En Croissant",
     "Menu.Application.Hide": "Hide En Croissant",
     "Menu.Application.Quit": "Quit En Croissant",
+    "Menu.ChooseNextMove": "Choose next move",
     "Menu.CopyVariationPGN": "Copy Variation PGN",
     "Menu.DeleteMove": "Delete Move",
     "Menu.Edit": "Edit",


### PR DESCRIPTION
## Summary
- When the current position has more than one possible next move (a variation branch), stepping forward with Next/→ now opens a floating picker centered over the move list instead of silently following the mainline.
- Navigate the options with →/↓ (down the list) or ←/↑ (up the list), confirm with Enter, or click an option directly. Escape or clicking the backdrop dismisses it without changing the position.
- Behavior is unchanged when there's only one legal next move, or while in practice/drill mode.

## Test plan
- [ ] Load/paste a PGN containing a variation (e.g. `1. e4 (1. d4) e5`)
- [ ] Step to the branch point and press → — picker should appear centered over the move list
- [ ] Use ↓/↑ and →/← to move the highlight, Enter to confirm
- [ ] Click an option directly to confirm
- [ ] Escape / click outside the panel closes it without moving
- [ ] Confirm normal single-move stepping is unaffected