### PR TITLE
fix: stop account downloads from re-importing the whole archive

### DIFF
--- a/src-tauri/src/db/create.sql
+++ b/src-tauri/src/db/create.sql
@@ -39,6 +39,7 @@ CREATE TABLE Games (
     FEN TEXT,
     Moves BLOB,
     PawnHome BLOB,
+    SourceID TEXT,
     FOREIGN KEY(EventID) REFERENCES Events,
     FOREIGN KEY(SiteID) REFERENCES Sites,
     FOREIGN KEY(WhiteID) REFERENCES Players,

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -61,7 +61,13 @@ pub use self::schema::puzzles;
 pub use self::schema::themes;
 pub use self::search::{is_position_in_db, search_position, PositionQueryJs, PositionStats};
 
-const DATABASE_VERSION: &str = "1.0.0";
+const DATABASE_VERSION: &str = "1.1.0";
+
+/// Unique index backing the duplicate-game check. It is partial so that games
+/// imported from PGNs without a usable game id (`SourceID` is NULL) are never
+/// rejected. Unlike `INDEXES_SQL` this is a correctness constraint, so it is
+/// created for every database and never dropped by `delete_indexes`.
+const SOURCE_ID_INDEX_SQL: &str = "CREATE UNIQUE INDEX IF NOT EXISTS games_source_id_idx ON Games(SourceID) WHERE SourceID IS NOT NULL;";
 
 const INDEXES_SQL: &str = include_str!("indexes.sql");
 
@@ -160,6 +166,10 @@ fn get_db_or_create(
                 .max_size(16)
                 .connection_customizer(Box::new(options))
                 .build(ConnectionManager::<SqliteConnection>::new(db_path))?;
+            // Migrate once, when the database is first opened: the schema
+            // declares columns that files written by older versions do not have
+            // yet, so even a plain read would fail against them.
+            migrate_db(&mut *pool.get()?)?;
             state
                 .connection_pool
                 .insert(db_path.to_string(), pool.clone());
@@ -217,6 +227,16 @@ pub struct TempGame {
     pub moves: Vec<u8>,
     pub position: Chess,
     pub material_count: MaterialColor,
+    /// Canonical URL of the game on the site it came from, when the PGN carries
+    /// one. Used to recognize games that are already in the database.
+    pub source_id: Option<String>,
+}
+
+/// Whether a `Site` header points at a single game instead of naming a venue.
+/// Lichess exports put the game URL there; chess.com uses the `Link` header.
+fn is_game_url(site: &str) -> bool {
+    site.strip_prefix("https://lichess.org/")
+        .is_some_and(|rest| !rest.is_empty())
 }
 
 impl TempGame {
@@ -271,6 +291,7 @@ impl TempGame {
             result: self.result.as_deref(),
             moves: self.moves.as_slice(),
             pawn_home: pawn_home as i32,
+            source_id: self.source_id.as_deref(),
         };
 
         create_game(db, new_game)?;
@@ -347,7 +368,15 @@ impl Visitor for Importer {
         } else if key == b"UTCTime" {
             self.game.time = Some(String::from_utf8_lossy(value.as_bytes()).to_string());
         } else if key == b"Site" {
-            self.game.site_name = Some(String::from_utf8_lossy(value.as_bytes()).to_string());
+            let site = String::from_utf8_lossy(value.as_bytes()).to_string();
+            if is_game_url(&site) {
+                self.game.source_id = Some(site.clone());
+            }
+            self.game.site_name = Some(site);
+        } else if key == b"Link" {
+            // chess.com puts the canonical game URL here, and it is more
+            // reliable than Site, so let it win.
+            self.game.source_id = Some(value.decode_utf8_lossy().into_owned());
         } else if key == b"Event" {
             self.game.event_name = Some(String::from_utf8_lossy(value.as_bytes()).to_string());
         } else if key == b"Result" {
@@ -531,6 +560,10 @@ pub async fn convert_pgn(
         )?;
     }
 
+    // Databases written by older versions have no SourceID column, so they
+    // cannot detect duplicates until they are migrated.
+    migrate_db(db)?;
+
     // start counting time
     let start = Instant::now();
 
@@ -705,16 +738,45 @@ pub struct DatabaseInfo {
     indexed: bool,
 }
 
+/// A single `name` column, as returned by `pragma_index_list` /
+/// `pragma_table_info`.
 #[derive(QueryableByName, Debug, Serialize)]
-struct IndexInfo {
+struct NameRow {
     #[diesel(sql_type = Text, column_name = "name")]
-    _name: String,
+    name: String,
 }
 
 fn check_index_exists(conn: &mut SqliteConnection) -> Result<bool, Error> {
+    // Only the indexes from `indexes.sql` count here: `games_source_id_idx` is
+    // always present and would otherwise report every database as indexed.
     let query = sql_query("SELECT name FROM pragma_index_list('Games');");
-    let indexes: Vec<IndexInfo> = query.load(conn)?;
-    Ok(!indexes.is_empty())
+    let indexes: Vec<NameRow> = query.load(conn)?;
+    Ok(indexes.iter().any(|i| i.name == "games_date_idx"))
+}
+
+/// Brings a database up to `DATABASE_VERSION`, and makes sure the unique index
+/// used for duplicate detection exists. Idempotent, and a no-op for files that
+/// hold no games (puzzle databases, and game databases before their tables are
+/// created), so it is safe to run whenever a database is opened.
+fn migrate_db(db: &mut SqliteConnection) -> Result<(), Error> {
+    let columns: Vec<NameRow> =
+        sql_query("SELECT name FROM pragma_table_info('Games');").load(db)?;
+    if columns.is_empty() {
+        return Ok(());
+    }
+    if !columns.iter().any(|c| c.name == "SourceID") {
+        db.batch_execute("ALTER TABLE Games ADD COLUMN SourceID TEXT;")?;
+    }
+    db.batch_execute(SOURCE_ID_INDEX_SQL)?;
+
+    insert_into(info::table)
+        .values((info::name.eq("Version"), info::value.eq(DATABASE_VERSION)))
+        .on_conflict(info::name)
+        .do_update()
+        .set(info::value.eq(DATABASE_VERSION))
+        .execute(db)?;
+
+    Ok(())
 }
 
 #[tauri::command]
@@ -2006,7 +2068,129 @@ mod tests {
         let mut conn = SqliteConnection::establish(":memory:").unwrap();
         conn.batch_execute("PRAGMA foreign_keys = ON;").unwrap();
         conn.batch_execute(CREATE_TABLES_SQL).unwrap();
+        migrate_db(&mut conn).unwrap();
         conn
+    }
+
+    #[test]
+    fn importer_reads_the_game_url_as_source_id() {
+        let pgn = r#"[Event "Live Chess"]
+[Site "Chess.com"]
+[Date "2026.02.27"]
+[White "W"]
+[Black "B"]
+[Result "*"]
+[Link "https://www.chess.com/game/live/1234"]
+
+1. e4 *
+
+[Event "Rated blitz game"]
+[Site "https://lichess.org/abcd1234"]
+[Date "2026.02.27"]
+[White "W"]
+[Black "B"]
+[Result "*"]
+
+1. e4 *
+
+[Event "Wijk aan Zee"]
+[Site "Wijk aan Zee NED"]
+[Date "2026.02.27"]
+[White "W"]
+[Black "B"]
+[Result "*"]
+
+1. e4 *
+"#;
+
+        let mut importer = Importer::new(None);
+        let games: Vec<TempGame> = BufferedReader::new(pgn.as_bytes())
+            .into_iter(&mut importer)
+            .flatten()
+            .flatten()
+            .collect();
+
+        assert_eq!(games.len(), 3);
+        assert_eq!(
+            games[0].source_id.as_deref(),
+            Some("https://www.chess.com/game/live/1234")
+        );
+        assert_eq!(
+            games[1].source_id.as_deref(),
+            Some("https://lichess.org/abcd1234")
+        );
+        // A venue name is not a game id, so this one stays eligible for import.
+        assert_eq!(games[2].source_id, None);
+    }
+
+    #[test]
+    fn reimporting_the_same_game_does_not_duplicate_it() {
+        let db = &mut setup_test_db();
+
+        let game = TempGame {
+            white_name: Some("Magnus".to_string()),
+            black_name: Some("Hikaru".to_string()),
+            date: Some("2026.02.27".to_string()),
+            time: Some("12:00:00".to_string()),
+            source_id: Some("https://lichess.org/abcd1234".to_string()),
+            ..Default::default()
+        };
+
+        game.insert_to_db(db).unwrap();
+        game.insert_to_db(db).unwrap();
+
+        let count: i64 = games::table.count().get_result(db).unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn games_without_a_source_id_are_still_imported() {
+        let db = &mut setup_test_db();
+
+        let game = TempGame {
+            white_name: Some("Magnus".to_string()),
+            black_name: Some("Hikaru".to_string()),
+            date: Some("2026.02.27".to_string()),
+            ..Default::default()
+        };
+
+        game.insert_to_db(db).unwrap();
+        game.insert_to_db(db).unwrap();
+
+        let count: i64 = games::table.count().get_result(db).unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn migrate_db_adds_the_source_id_column_to_old_databases() {
+        let mut conn = SqliteConnection::establish(":memory:").unwrap();
+        // Schema as it was before SourceID existed.
+        conn.batch_execute(&CREATE_TABLES_SQL.replace("SourceID TEXT,", ""))
+            .unwrap();
+
+        migrate_db(&mut conn).unwrap();
+
+        let columns: Vec<NameRow> = sql_query("SELECT name FROM pragma_table_info('Games');")
+            .load(&mut conn)
+            .unwrap();
+        assert!(columns.iter().any(|c| c.name == "SourceID"));
+
+        // Every column the schema declares must now be readable, otherwise
+        // browsing a database written by an older version fails.
+        games::table.load::<Game>(&mut conn).unwrap();
+
+        // Running it again on an already migrated database is a no-op.
+        migrate_db(&mut conn).unwrap();
+    }
+
+    #[test]
+    fn migrate_db_ignores_databases_without_games() {
+        // Puzzle databases go through the same connection pool.
+        let mut conn = SqliteConnection::establish(":memory:").unwrap();
+        conn.batch_execute("CREATE TABLE Puzzles (ID INTEGER PRIMARY KEY);")
+            .unwrap();
+
+        migrate_db(&mut conn).unwrap();
     }
 
     #[test]
@@ -2041,8 +2225,10 @@ mod tests {
                 fen: None,
                 moves: &[],
                 pawn_home: 0,
+                source_id: None,
             },
         )
+        .unwrap()
         .unwrap();
 
         // Verify everything exists: 3 players (Unknown + 2), 2 events, 2 sites
@@ -2140,8 +2326,10 @@ mod tests {
                     fen: None,
                     moves: &[],
                     pawn_home: 0,
+                    source_id: None,
                 },
             )
+            .unwrap()
             .unwrap()
         };
 

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -62,6 +62,7 @@ pub struct Game {
     pub fen: Option<String>,
     pub moves: Vec<u8>,
     pub pawn_home: i32,
+    pub source_id: Option<String>,
 }
 
 #[derive(Insertable, Debug)]
@@ -85,6 +86,7 @@ pub struct NewGame<'a> {
     pub fen: Option<&'a str>,
     pub moves: &'a [u8],
     pub pawn_home: i32,
+    pub source_id: Option<&'a str>,
 }
 
 #[derive(Default, Debug, Queryable, Serialize, Deserialize, Identifiable, Clone)]

--- a/src-tauri/src/db/ops.rs
+++ b/src-tauri/src/db/ops.rs
@@ -60,14 +60,17 @@ pub fn create_site(conn: &mut SqliteConnection, name: &str) -> Result<Site, dies
     }
 }
 
-/// Creates a new game in the database, and returns the game's ID.
+/// Creates a new game in the database, and returns it.
+/// Returns `None` if the game was skipped because another game with the same
+/// `SourceID` is already stored.
 pub fn create_game(
     conn: &mut SqliteConnection,
     game: NewGame,
-) -> Result<Game, diesel::result::Error> {
+) -> Result<Option<Game>, diesel::result::Error> {
     use crate::db::schema::games;
 
     diesel::insert_or_ignore_into(games::table)
         .values(&game)
         .get_result(conn)
+        .optional()
 }

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -81,6 +81,8 @@ diesel::table! {
         moves -> Binary,
         #[sql_name = "PawnHome"]
         pawn_home -> Integer,
+        #[sql_name = "SourceID"]
+        source_id -> Nullable<Text>,
     }
 }
 

--- a/src/components/common/AccountCards.tsx
+++ b/src/components/common/AccountCards.tsx
@@ -19,6 +19,20 @@ import type { Session } from "@/utils/session";
 import { AccountCard } from "../home/AccountCard";
 import { EmptyAccounts } from "../home/EmptyAccounts";
 
+// The database file keeps whatever casing the account had when it was first
+// downloaded, and on case-insensitive filesystems later downloads keep writing
+// to it. Matching case-sensitively would make the card think nothing has been
+// downloaded yet and re-import the whole archive on every download.
+function findAccountDatabase(
+  databases: DatabaseInfo[],
+  username: string | undefined,
+  type: "lichess" | "chesscom",
+) {
+  if (!username) return null;
+  const expected = `${username}_${type}.db3`.toLowerCase();
+  return databases.find((db) => db.filename.toLowerCase() === expected) ?? null;
+}
+
 function AccountCards({
   databases,
   setDatabases,
@@ -216,7 +230,7 @@ function LichessOrChessCom({
         key={account.id}
         token={lichessSession.accessToken}
         type="lichess"
-        database={databases.find((db) => db.filename === `${account.username}_lichess.db3`) ?? null}
+        database={findAccountDatabase(databases, account.username, "lichess")}
         title={account.username}
         updatedAt={session.updatedAt}
         total={totalGames}
@@ -262,10 +276,7 @@ function LichessOrChessCom({
         key={session.chessCom.username}
         type="chesscom"
         title={session.chessCom.username}
-        database={
-          databases.find((db) => db.filename === `${session.chessCom?.username}_chesscom.db3`) ??
-          null
-        }
+        database={findAccountDatabase(databases, session.chessCom.username, "chesscom")}
         updatedAt={session.updatedAt}
         total={totalGames}
         stats={getStats(session.chessCom.stats)}

--- a/src/components/home/AccountCard.tsx
+++ b/src/components/home/AccountCard.tsx
@@ -157,21 +157,38 @@ export function AccountCard({
   const percentage =
     effectiveTotal === 0 ? "0.00" : ((downloadedGames / effectiveTotal) * 100).toFixed(2);
 
+  // Everything that keeps a download incremental hangs off this cursor: when it
+  // comes back null the whole archive is fetched and re-imported. So look past
+  // the newest row if its date is missing or unparseable ("????.??.??"), and
+  // fall back to the start of the day when only the time is missing.
   async function getLastGameDate({ database }: { database: DatabaseInfo }) {
     const games = await query_games(database.file, {
       options: {
         page: 1,
-        pageSize: 1,
+        pageSize: 20,
         sort: "date",
         direction: "desc",
-        skipCount: false,
+        skipCount: true,
       },
     });
-    if (games.count! > 0 && games.data[0].date && games.data[0].time) {
-      const [year, month, day] = games.data[0].date.split(".").map(Number);
-      const [hour, minute, second] = games.data[0].time.split(":").map(Number);
-      const d = Date.UTC(year, month - 1, day, hour, minute, second);
-      return d;
+    for (const game of games.data) {
+      if (!game.date) continue;
+      const [year, month, day] = game.date.split(".").map(Number);
+      if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+        continue;
+      }
+      const [hour, minute, second] = (game.time ?? "00:00:00").split(":").map(Number);
+      const d = Date.UTC(
+        year,
+        month - 1,
+        day,
+        Number.isFinite(hour) ? hour : 0,
+        Number.isFinite(minute) ? minute : 0,
+        Number.isFinite(second) ? second : 0,
+      );
+      if (Number.isFinite(d)) {
+        return d;
+      }
     }
     return null;
   }
@@ -211,20 +228,20 @@ export function AccountCard({
                 disabled={loading}
                 onClick={async () => {
                   setLoading(true);
-                  const lastGameDate = database ? await getLastGameDate({ database }) : null;
-                  if (type === "lichess") {
-                    await downloadLichess(
-                      title,
-                      lastGameDate,
-                      total - downloadedGames,
-                      setProgress,
-                      token,
-                    );
-                  } else {
-                    await downloadChessCom(title, lastGameDate);
-                  }
-                  const p = await resolve(databaseDir, `${title}_${type}.pgn`);
                   try {
+                    const lastGameDate = database ? await getLastGameDate({ database }) : null;
+                    if (type === "lichess") {
+                      await downloadLichess(
+                        title,
+                        lastGameDate,
+                        total - downloadedGames,
+                        setProgress,
+                        token,
+                      );
+                    } else {
+                      await downloadChessCom(title, lastGameDate);
+                    }
+                    const p = await resolve(databaseDir, `${title}_${type}.pgn`);
                     await convert(p, lastGameDate);
                     const dbPath = p.replace(".pgn", ".db3");
                     await commands.deleteEmptyGames(dbPath);
@@ -240,8 +257,8 @@ export function AccountCard({
                       targetDatabaseTitle: null,
                       sourceFileName: null,
                     }));
+                    setLoading(false);
                   }
-                  setLoading(false);
                 }}
               >
                 <IconDownload size="1rem" />

--- a/src/utils/chess.com/api.tsx
+++ b/src/utils/chess.com/api.tsx
@@ -105,7 +105,7 @@ export async function downloadChessCom(player: string, timestamp: number | null)
   const archives = await getGameArchives(player);
   const file = await resolve(await getDatabasesDir(), `${player}_chesscom.pgn`);
   info(`Found ${archives.archives.length} archives for ${player}`);
-  writeTextFile(file, "", {
+  await writeTextFile(file, "", {
     append: false,
   });
   const filteredArchives = archives.archives.filter((archive) => {
@@ -133,7 +133,7 @@ export async function downloadChessCom(player: string, timestamp: number | null)
       return;
     }
 
-    writeTextFile(file, games.data.games.map((g) => g.pgn).join("\n"), {
+    await writeTextFile(file, games.data.games.map((g) => g.pgn).join("\n"), {
       append: true,
     });
     events.progressEvent.emit({

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -109,7 +109,9 @@ async function getDatabase(name: string): Promise<DatabaseInfo> {
     }
     return {
         type: "error",
-        filename: path,
+        // Must stay the bare file name like the success case, otherwise callers
+        // that look a database up by filename silently stop finding it.
+        filename: name,
         file: path,
         error: res.error,
         indexed: false,


### PR DESCRIPTION
## Problem

Downloading games for a linked Lichess/Chess.com account can append the **entire** archive again instead of just the new games, and nothing stops the duplicates from landing in the database.

Dedup today is a date cursor: `getLastGameDate()` reads the newest game out of the account's `.db3`, and that value feeds Lichess's `since=`, the chess.com archive-month filter, and `convert_pgn`'s `timestamp` (`Importer::end_headers` skips games at or before it). If the cursor comes back `null`, **every** layer independently falls back to "everything":

- `downloadChessCom` — `new Date(timestamp ?? 0)` → epoch → every archive passes the filter, and the PGN is truncated and rewritten in full.
- `downloadLichess` — no `since` param → the entire game history.
- `convert` — `timestamp ? timestamp / 1000 : null` → the importer never skips.

And there is no backstop: `Games` has only `ID INTEGER PRIMARY KEY AUTOINCREMENT`, so the `insert_or_ignore_into` in `create_game` has no constraint to conflict with and inserts every row. On my own database this had happened about four times over — 3950 distinct games spread across 15561 rows, with `MAX(ID)` far past the row count. The app log for the last run shows the cursor arriving as `null`:

```
[INFO] converting .../<user>_chesscom.pgn null
```

and the PGN on disk held the full 2023→2026 archive rather than the two months that should have been fetched.

There are several ways the cursor ends up `null`, which is why this reproduces so easily: the account database is looked up with a case-sensitive `db.filename === \`\${username}_\${type}.db3\`` (the file keeps the casing it was first created with, and on case-insensitive filesystems later downloads keep writing to it); `getDatabase` returns the full path as `filename` on its error branch, so a database that fails `get_db_info` can never be matched; and `getLastGameDate` gives up if the single newest row has no `UTCTime` or an unparseable date such as `????.??.??`.

## Fix

**Give games a real identity.** New `Games.SourceID` column holding the canonical game URL, taken from the `Link` header (chess.com) or from a `Site` header that points at a game rather than naming a venue (lichess), plus a unique index over it:

```sql
CREATE UNIQUE INDEX IF NOT EXISTS games_source_id_idx ON Games(SourceID) WHERE SourceID IS NOT NULL;
```

It is **partial** on purpose, so PGNs with no usable game id (`[Site "Wijk aan Zee NED"]`) are never rejected, and it lives outside `indexes.sql` because it is a correctness constraint rather than a search index — `delete_indexes` must not drop it. `create_game` now returns `Option<Game>` so an ignored insert is not an error that aborts the import transaction.

**Migrate on open, not just on convert.** The schema now declares a column older files don't have, so even a plain read would fail with `no such column: Games.SourceID`. `migrate_db` runs once per database when its connection pool is created, and no-ops for files with no `Games` table so puzzle databases are unaffected. `check_index_exists` is narrowed to `games_date_idx`, otherwise the new index would make every database report itself as indexed.

**Make the cursor harder to lose.** `getLastGameDate` scans past rows with a missing or unparseable date instead of giving up on the first, and falls back to the start of the day when only the time is missing. `getDatabase` returns the bare filename on its error branch. Account databases are matched case-insensitively.

**Two smaller bugs in the same path.** `downloadChessCom` never awaited its `writeTextFile` calls, so the truncate and the per-archive appends raced the conversion that reads the file; and the download handler could leave the button stuck spinning because `setLoading(false)` sat outside the `try`.

## Behaviour changes worth flagging

- Importing a PGN of a Lichess/chess.com game that is already in the database is now **silently skipped**. That is the intent for account downloads, and matches the existing `delete_duplicated_games` command treating duplicates as unwanted, but it does mean re-importing an annotated copy of a game you already have will no longer add a second row.
- Existing databases get `SourceID = NULL` on their current rows — the data to backfill it was never stored. Those rows won't dedupe against a fresh import, so the date cursor still has to cover that gap; everything imported after the migration is keyed and idempotent.

## Testing

- `cargo test db::` — 29 pass, including four new tests: source-id extraction from `Link` / lichess `Site` / a venue name, duplicate rejection, games without a source id still importing twice, and migration of a pre-`SourceID` schema (asserting a full `Game` row loads afterwards) plus the no-`Games`-table no-op.
  - `db::search::tests::get_move_after_exact_match_test` fails, but it fails identically on `master` — pre-existing and unrelated to this change.
- `pnpm lint:ci` equivalents all clean: `tsgo --noEmit`, `oxfmt --check`, `oxlint` (warnings only, all pre-existing), `i18next-cli extract --ci`.
- `pnpm test` — 18/18 pass.
- `cargo fmt --check` clean for the files touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)