### PR TITLE
fix: bind database title and description instead of interpolating SQL

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -175,11 +175,19 @@ fn update_info_count(
     name: &str,
     value: i64,
 ) -> Result<(), diesel::result::Error> {
+    set_info_value(db, name, &value.to_string())
+}
+
+fn set_info_value(
+    db: &mut SqliteConnection,
+    name: &str,
+    value: &str,
+) -> Result<(), diesel::result::Error> {
     diesel::insert_into(info::table)
-        .values((info::name.eq(name), info::value.eq(value.to_string())))
+        .values((info::name.eq(name), info::value.eq(value)))
         .on_conflict(info::name)
         .do_update()
-        .set(info::value.eq(value.to_string()))
+        .set(info::value.eq(value))
         .execute(db)?;
     Ok(())
 }
@@ -521,14 +529,9 @@ pub async fn convert_pgn(
 
     if !db_exists {
         db.batch_execute(CREATE_TABLES_SQL)?;
-        db.batch_execute(
-            format!(
-                "INSERT INTO Info (Name, Value) VALUES (\"Version\", \"{DATABASE_VERSION}\");
-                INSERT INTO Info (Name, Value) VALUES (\"Title\", \"{title}\");
-                INSERT INTO Info (Name, Value) VALUES (\"Description\", \"{description}\");"
-            )
-            .as_str(),
-        )?;
+        set_info_value(db, "Version", DATABASE_VERSION)?;
+        set_info_value(db, "Title", &title)?;
+        set_info_value(db, "Description", &description)?;
     }
 
     // start counting time
@@ -2007,6 +2010,18 @@ mod tests {
         conn.batch_execute("PRAGMA foreign_keys = ON;").unwrap();
         conn.batch_execute(CREATE_TABLES_SQL).unwrap();
         conn
+    }
+
+    #[test]
+    fn set_info_value_stores_title_containing_quotes() {
+        let db = &mut setup_test_db();
+        set_info_value(db, "Title", r#"A "quoted" title"#).unwrap();
+        let stored: Option<String> = info::table
+            .filter(info::name.eq("Title"))
+            .select(info::value)
+            .first(db)
+            .unwrap();
+        assert_eq!(stored.as_deref(), Some(r#"A "quoted" title"#));
     }
 
     #[test]


### PR DESCRIPTION
## What

`convert_pgn` in `src-tauri/src/db/mod.rs` (around lines 524-531 on current master) built three INSERT statements with `format!`, interpolating the command's `title` and `description` into SQL. A double quote in either value produced invalid SQL.

The same file already writes Title and Description with Diesel binds in `edit_db_info` (around lines 800-816). This change uses that insert for Version, Title and Description when creating a database.

## Test

`set_info_value_stores_title_containing_quotes` writes a title that contains a quote and reads it back.

## Scope

Against current `master` (`9654961d`). Other open PRs also edit `db/mod.rs` for other reasons (#892, #861, #795, #780). This PR only changes the create-path Info inserts.
