### PR TITLE
fix: store file lastModified as epoch milliseconds

### DIFF
--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -53,7 +53,7 @@ export async function openFile(
             name: file,
             path: file,
             numGames: count,
-            lastModified: new Date().getUTCSeconds(),
+            lastModified: Date.now(),
         };
 
         if (pgn) {
@@ -130,6 +130,6 @@ export async function createFile({
         path: file,
         numGames,
         metadata,
-        lastModified: new Date().getUTCSeconds(),
+        lastModified: Date.now(),
     });
 }


### PR DESCRIPTION
## What

`src/utils/files.ts` (lines 56 and 133 on current master) used `new Date().getUTCSeconds()` as `lastModified` when opening an existing file or creating a new one. `getUTCSeconds()` returns 0-59, not a timestamp.

This uses `Date.now()` (milliseconds since epoch) at both sites.

## Related

This is the invalid-timestamps half of #793. It does not address the `selectedTournamet` claim in that issue.
